### PR TITLE
fix: add WebSocket proxy location block for batch progress

### DIFF
--- a/nginx/locations.conf
+++ b/nginx/locations.conf
@@ -39,10 +39,6 @@ location /api/ {
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-Port $server_port;
 
-    # WebSocket support for batch processing progress
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-
     # Timeouts - adjust for long-running validations and large uploads
     proxy_connect_timeout 600s;
     proxy_send_timeout 600s;
@@ -57,6 +53,26 @@ location /api/ {
 
     # Don't pass server version in headers
     proxy_hide_header X-Powered-By;
+}
+
+# WebSocket proxy for batch progress updates
+location /ws/ {
+    proxy_pass http://backend;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Long timeouts for persistent WebSocket connections
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+    proxy_connect_timeout 7s;
+
+    # Disable buffering for real-time updates
+    proxy_buffering off;
 }
 
 # Metrics endpoint - restrict to internal networks

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,6 +7,12 @@ limit_req_zone $binary_remote_addr zone=general_limit:10m rate=30r/s;
 # Connection limiting
 limit_conn_zone $binary_remote_addr zone=conn_limit:10m;
 
+# WebSocket upgrade mapping
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 # Upstream backend servers
 upstream backend {
     server chemaudit-backend-prod:8000 max_fails=3 fail_timeout=30s;
@@ -56,13 +62,33 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
 
         proxy_connect_timeout 600s;
         proxy_send_timeout 600s;
         proxy_read_timeout 600s;
         proxy_buffering off;
         proxy_request_buffering off;
+    }
+
+    # WebSocket proxy for batch progress updates
+    location /ws/ {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Long timeouts for persistent WebSocket connections
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_connect_timeout 7s;
+
+        # Disable buffering for real-time updates
+        proxy_buffering off;
     }
 
     # Metrics endpoint - restrict to internal


### PR DESCRIPTION
Nginx was missing a dedicated /ws/ location block, causing WebSocket connections to wss://…/ws/batch/{jobId} to fall through to the SPA fallback and serve index.html instead of proxying to the backend.

Changes:
- Add map $http_upgrade $connection_upgrade for proper upgrade handling
- Add location /ws/ block with WebSocket headers and 24h timeouts
- Fix conflicting Connection headers in /api/ and locations.conf