### PR TITLE
fix(security): stop reflecting user input in profiler error responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,9 @@ docker-compose logs -f      # View logs
 ./deploy.sh medium          # Deploy with profile (small/medium/large/xl/coconut)
 ```
 
+## Git
+- Do NOT add "Co-Authored-By" lines to commit messages
+
 ## Code Style
 - Python: Ruff (lint + format, line-length=100), type hints required
 - TypeScript: ESLint + strict mode

--- a/backend/app/api/routes/profiler.py
+++ b/backend/app/api/routes/profiler.py
@@ -56,7 +56,7 @@ async def full_profile(
     if mol is None:
         raise HTTPException(
             status_code=400,
-            detail={"error": "Invalid SMILES", "smiles": body.smiles},
+            detail="Invalid SMILES",
         )
 
     profile = compute_full_profile(mol)
@@ -97,7 +97,7 @@ async def shape_3d(
     if mol is None:
         raise HTTPException(
             status_code=400,
-            detail={"error": "Invalid SMILES", "smiles": body.smiles},
+            detail="Invalid SMILES",
         )
 
     result = compute_3d_shape(mol)
@@ -141,7 +141,7 @@ async def sa_comparison(
     if mol is None:
         raise HTTPException(
             status_code=400,
-            detail={"error": "Invalid SMILES", "smiles": body.smiles},
+            detail="Invalid SMILES",
         )
 
     return compute_sa_comparison(mol, body.smiles)
@@ -174,7 +174,7 @@ async def ligand_efficiency(
     if mol is None:
         raise HTTPException(
             status_code=400,
-            detail={"error": "Invalid SMILES", "smiles": body.smiles},
+            detail="Invalid SMILES",
         )
 
     result = compute_ligand_efficiency(mol, body.activity_value, body.activity_type)
@@ -213,7 +213,7 @@ async def custom_mpo(
     if mol is None:
         raise HTTPException(
             status_code=400,
-            detail={"error": "Invalid SMILES", "smiles": body.smiles},
+            detail="Invalid SMILES",
         )
 
     profile_dicts = [p.model_dump() for p in body.profile]


### PR DESCRIPTION
Remove body.smiles from HTTPException detail in all profiler endpoints to prevent information exposure (CodeQL: stack trace information leak). Also add git commit style preference to CLAUDE.md.