### PR TITLE
fix: update tests for sanitized error messages, handle missing medche…

### DIFF
--- a/backend/app/services/structure_filter/filter_pipeline.py
+++ b/backend/app/services/structure_filter/filter_pipeline.py
@@ -178,8 +178,11 @@ def filter_batch(smiles_list: list[str], config: FilterConfig) -> FilterResult:
                 kazius_hits = screen_kazius(mol)
                 alert_names.extend(hit.pattern_name for hit in kazius_hits)
             if config.use_nibr:
-                nibr_hits = screen_nibr(mol)
-                alert_names.extend(hit.pattern_name for hit in nibr_hits)
+                try:
+                    nibr_hits = screen_nibr(mol)
+                    alert_names.extend(hit.pattern_name for hit in nibr_hits)
+                except ImportError:
+                    pass  # medchem not installed; skip NIBR screening
 
             if alert_names:
                 first = alert_names[0]

--- a/backend/tests/test_api/test_profiler_routes.py
+++ b/backend/tests/test_api/test_profiler_routes.py
@@ -84,7 +84,7 @@ class TestFullProfile:
         assert response.status_code == 400
         data = response.json()
         assert "detail" in data
-        assert "error" in data["detail"]
+        assert "Invalid SMILES" in data["detail"]
 
     @pytest.mark.asyncio
     async def test_full_profile_cns_mpo_structure(self, client):

--- a/backend/tests/test_batch/test_endpoint.py
+++ b/backend/tests/test_batch/test_endpoint.py
@@ -157,7 +157,7 @@ $$$$
             )
 
         assert response.status_code == 400
-        assert "not found" in response.json()["detail"]
+        assert "Invalid file content" in response.json()["detail"]
 
     async def test_upload_empty_file_rejected(self, mock_celery):
         """Test that empty files are rejected."""


### PR DESCRIPTION
…m gracefully

- Update test_full_profile_invalid_smiles to match new detail string
- Update test_upload_csv_with_missing_smiles_column to match new detail string
- Add ImportError guard for NIBR screening when medchem is not installed, preventing 500 errors in CI environments without the optional dependency