### PR TITLE
docs(mcp): add MCP server documentation and fix nginx proxy for /mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 [Quick Start](#-quick-start) &bull;
 [Documentation](https://www.kohulanr.com/ChemAudit/) &bull;
 [API](#-api-reference) &bull;
+[MCP](#-mcp-server-model-context-protocol) &bull;
 [CLI](#-command-line-interface) &bull;
 [Contributing](#-contributing)
 
@@ -428,6 +429,72 @@ curl -X POST http://localhost:8000/api/v1/profiler/full \
   -H "Content-Type: application/json" \
   -d '{"smiles": "CC(=O)Oc1ccccc1C(=O)O"}'
 ```
+
+---
+
+## 🤖 MCP Server (Model Context Protocol)
+
+ChemAudit exposes an MCP server that lets AI assistants (Claude, Cursor, Windsurf, etc.) call its chemistry tools directly. Built with [`fastapi-mcp`](https://github.com/tadata-ru/fastapi-mcp), it auto-generates **~68 tools** from the existing API — no separate server to run.
+
+### Quick Setup
+
+Add to your MCP client config (e.g. `claude_desktop_config.json`, `.cursor/mcp.json`, or `~/.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "chemaudit": {
+      "type": "sse",
+      "url": "http://localhost:8001/mcp"
+    }
+  }
+}
+```
+
+For production deployments behind nginx, use:
+
+```json
+{
+  "mcpServers": {
+    "chemaudit": {
+      "type": "sse",
+      "url": "https://your-domain.com/mcp"
+    }
+  }
+}
+```
+
+### Available Tool Categories
+
+| Category | Tools | Examples |
+|----------|-------|---------|
+| **Validation** | 4 | Validate molecule, list checks, compute similarity |
+| **Scoring** | 2 | ML-readiness score, radar comparison |
+| **Standardization** | 2 | ChEMBL-compatible standardization |
+| **Alerts & Safety** | 6 | PAINS/BRENK screening, CYP/hERG/bRo5/REOS |
+| **Compound Profiler** | 5 | PFI, 3D shape, SA comparison, ligand efficiency, MPO |
+| **Identifier Resolution** | 1 | Resolve SMILES, InChI, CAS, ChEMBL ID, name, etc. |
+| **Database Integrations** | 6 | PubChem, ChEMBL, COCONUT, Wikidata, SureChEMBL |
+| **Diagnostics** | 5 | SMILES errors, InChI diff, round-trip, cross-pipeline |
+| **QSAR-Ready** | 5 | Single/batch curation pipeline |
+| **Structure Filter** | 7 | Generative model funnel, REINVENT scoring |
+| **Dataset Intelligence** | 6 | Health audit, contradictions, dataset diff |
+| **Batch & Export** | 11 | Upload, process, analytics, export (CSV/Excel/SDF/JSON/PDF) |
+| **Scoring Profiles** | 7 | Create, manage, import/export custom profiles |
+
+### Security
+
+Admin endpoints (API key management, config, sessions) are **never** exposed via MCP. A runtime assertion on startup verifies no admin tags leak into the MCP allowlist.
+
+### Example AI Interaction
+
+Once connected, you can ask your AI assistant:
+
+> "Validate the molecule CC(=O)Oc1ccccc1C(=O)O and check for PAINS alerts"
+
+> "Resolve aspirin across PubChem, ChEMBL, and COCONUT and compare the structures"
+
+> "Run the QSAR-ready pipeline on this SMILES: CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
 
 ---
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -94,6 +94,32 @@ server {
         proxy_buffering off;
     }
 
+    # MCP (Model Context Protocol) server - SSE transport
+    location /mcp {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+
+        # SSE requires no buffering and long timeouts
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        chunked_transfer_encoding on;
+
+        # Allow CORS for MCP clients
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+    }
+
     # Metrics endpoint - restrict to internal
     location /metrics {
         allow 10.0.0.0/8;


### PR DESCRIPTION
- Add MCP Server section to README with setup instructions for Claude, Cursor, and other MCP clients (SSE transport config)
- Document all 68 available tool categories with examples
- Add /mcp nav link to README header
- Add nginx location block for /mcp with SSE-appropriate headers (proxy_buffering off, long timeouts, chunked transfer, CORS)
- Production MCP endpoint was previously unreachable through nginx