### PR TITLE
fix: sticky header and code cleanup

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -42,12 +42,12 @@ const orbConfigs = [
 ];
 
 /**
- * Premium layout wrapper with ambient gradient background and refined footer
+ * Layout wrapper with ambient gradient background and cinematic footer.
+ * The inner content div sits above the fixed footer via z-index stacking.
  */
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="relative w-full bg-[var(--color-surface)] min-h-screen overflow-x-hidden">
-      {/* Main content sits above the fixed cinematic footer */}
+    <div className="relative w-full bg-[var(--color-surface)] min-h-screen">
       <div className="relative z-10 w-full bg-[var(--color-surface)]">
         {/* Ambient gradient orbs */}
         <div className="fixed inset-0 overflow-hidden pointer-events-none z-0">
@@ -61,7 +61,7 @@ export function Layout({ children }: LayoutProps) {
           ))}
         </div>
 
-        {/* Premium grid pattern overlay */}
+        {/* Grid pattern overlay */}
         <div
           className="fixed inset-0 pointer-events-none opacity-[0.015] dark:opacity-[0.025] z-0"
           style={{
@@ -73,10 +73,8 @@ export function Layout({ children }: LayoutProps) {
           }}
         />
 
-        {/* Header - sticky at top */}
         <Header />
 
-        {/* Main content */}
         <motion.main
           className="relative flex-1 py-10 z-0"
           initial={{ opacity: 0, y: 12 }}
@@ -87,7 +85,6 @@ export function Layout({ children }: LayoutProps) {
         </motion.main>
       </div>
 
-      {/* Cinematic Footer - revealed as user scrolls past content */}
       <CinematicFooter />
     </div>
   );

--- a/frontend/src/components/ui/BB8ThemeToggle.tsx
+++ b/frontend/src/components/ui/BB8ThemeToggle.tsx
@@ -24,11 +24,7 @@ export function BB8ThemeToggle({ className }: BB8ThemeToggleProps) {
 
   return (
     <StyledWrapper
-      className={cn(
-        'overflow-visible',
-        'transition-all duration-300',
-        className,
-      )}
+      className={cn('overflow-visible transition-all duration-300', className)}
     >
       <label className="bb8-toggle" aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}>
         <input

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -103,6 +103,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Connection '';
+        proxy_connect_timeout 7s;
 
         # SSE requires no buffering and long timeouts
         proxy_buffering off;


### PR DESCRIPTION
- Remove overflow-x-hidden from Layout outer div that broke position:sticky on the header in Safari
- Remove redundant comments from Layout.tsx
- Consolidate BB8ThemeToggle cn() call
- Add proxy_connect_timeout 7s to nginx /mcp block for consistency