### PR TITLE
fix(batch): accept single-column and headerless delimited files

### DIFF
--- a/backend/app/services/batch/file_parser.py
+++ b/backend/app/services/batch/file_parser.py
@@ -9,13 +9,29 @@ Includes security validations for production use.
 import io
 import logging
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import pandas as pd
-from rdkit import Chem
+from rdkit import Chem, RDLogger
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _silence_rdkit() -> Iterator[None]:
+    """Suppress RDKit log output for the duration of the block.
+
+    Used when probing whether a string parses as SMILES — failures are
+    expected here and the noisy default logging is not useful.
+    """
+    RDLogger.DisableLog("rdApp.*")
+    try:
+        yield
+    finally:
+        RDLogger.EnableLog("rdApp.*")
+
 
 # =============================================================================
 # File Content Type Validation
@@ -80,9 +96,7 @@ def validate_file_content_type(
 
     for pattern in SUSPICIOUS_PATTERNS:
         if re.search(pattern, sample, re.IGNORECASE):
-            logger.warning(
-                f"Suspicious pattern detected in file '{filename}': {pattern}"
-            )
+            logger.warning(f"Suspicious pattern detected in file '{filename}': {pattern}")
             return False, "File contains potentially malicious content"
 
     # Check file magic bytes / signatures
@@ -154,7 +168,12 @@ def _validate_sdf_content(content: bytes, filename: str) -> Tuple[bool, Optional
 
 def _validate_csv_content(content: bytes, filename: str) -> Tuple[bool, Optional[str]]:
     """
-    Validate that content looks like a valid CSV file.
+    Validate that content looks like a valid delimited text file.
+
+    Accepts CSV, TSV, and plain-text files — including single-column files
+    that contain no explicit delimiters in the header (e.g. a TSV with one
+    SMILES per line). Rejects binary files, unreadable encodings, and
+    content too small to be usable.
 
     Args:
         content: Raw file bytes
@@ -188,15 +207,11 @@ def _validate_csv_content(content: bytes, filename: str) -> Tuple[bool, Optional
                 "File is not valid text (could not decode as UTF-8 or Latin-1)",
             )
 
-    # Check for common CSV structure (has lines and delimiters)
-    lines = text.split("\n")
-    if len(lines) < 2:
-        return False, "CSV file must have at least a header row and one data row"
-
-    # Check that first line (header) has comma or tab delimiters
-    header = lines[0]
-    if "," not in header and "\t" not in header:
-        return False, "CSV file must use comma or tab delimiters"
+    # Require at least one non-empty line. splitlines() handles all common
+    # line endings (LF, CRLF, CR) so old-Mac-style files are not rejected here.
+    non_empty_lines = [line for line in text.splitlines() if line.strip()]
+    if not non_empty_lines:
+        return False, "File appears to be empty"
 
     return True, None
 
@@ -280,8 +295,10 @@ def _detect_delimiter(content: bytes) -> str:
     """
     Detect the delimiter used in a delimited text file.
 
-    Examines the first line (header) to determine if the file uses
-    tabs or commas as delimiters.
+    Examines the first non-empty line to determine if the file uses
+    tabs or commas as delimiters. Single-column files (no delimiter in
+    the first line) fall through to the comma default; the parser
+    treats them as a one-column file either way.
 
     Args:
         content: Raw file bytes
@@ -289,9 +306,8 @@ def _detect_delimiter(content: bytes) -> str:
     Returns:
         Delimiter character ('\\t' for tab, ',' for comma)
     """
-    # Get the first line
+    # Get the first line (decode robustly, splitlines handles LF/CRLF/CR)
     try:
-        # Try UTF-8 first
         text = content.decode("utf-8")
     except UnicodeDecodeError:
         try:
@@ -299,17 +315,260 @@ def _detect_delimiter(content: bytes) -> str:
         except UnicodeDecodeError:
             return ","  # Default to comma
 
-    first_line = text.split("\n")[0] if "\n" in text else text
+    first_line = ""
+    for line in text.splitlines():
+        if line.strip():
+            first_line = line
+            break
 
-    # Count delimiters in the first line
     tab_count = first_line.count("\t")
     comma_count = first_line.count(",")
 
-    # Use the more common delimiter, preferring tab if equal
-    # (since tabs are less likely to appear in data)
+    # Prefer tab when at least as common as comma — tabs rarely appear in SMILES
+    # or chemical names, so a tab in the header is a strong signal for TSV.
     if tab_count > 0 and tab_count >= comma_count:
         return "\t"
     return ","
+
+
+# Column-name keywords that must never be treated as SMILES data, even when
+# RDKit would technically parse them (e.g. "mol", "N", "I", "S"). Used by
+# the headerless-file detector to avoid misclassifying common headers.
+_HEADER_KEYWORDS = frozenset(
+    {
+        "smiles",
+        "smi",
+        "canonical_smiles",
+        "isomeric_smiles",
+        "input_smiles",
+        "mol_smiles",
+        "structure",
+        "mol",
+        "molecule",
+        "name",
+        "id",
+        "compound",
+        "compound_id",
+        "compound_name",
+        "title",
+        "label",
+        "identifier",
+        "inchi",
+        "inchikey",
+        "inchi_key",
+        "cas",
+        "cas_number",
+        "cas_rn",
+        "activity",
+        "value",
+        "target",
+        "assay",
+        "ic50",
+        "ki",
+        "mw",
+        "molweight",
+        "logp",
+        "tpsa",
+    }
+)
+
+
+def _looks_like_smiles_value(value: str) -> bool:
+    """Return True if ``value`` parses as a valid SMILES via RDKit.
+
+    Used to detect whether the first row of a delimited file is data
+    (headerless) or a column header. A value is considered SMILES-like
+    only when:
+
+    - It is non-empty, bounded, and contains no whitespace
+      (SMILES strings never contain whitespace).
+    - It is not a common column-name keyword (see ``_HEADER_KEYWORDS``) —
+      even if RDKit would parse it (e.g. ``N`` as nitrogen).
+    - RDKit produces a sanitized molecule with at least one atom.
+    """
+    if not value or not isinstance(value, str):
+        return False
+    cleaned = value.strip()
+    if not cleaned or len(cleaned) > MAX_SMILES_LENGTH:
+        return False
+    if any(ch.isspace() for ch in cleaned):
+        return False
+    if cleaned.lower() in _HEADER_KEYWORDS:
+        return False
+    try:
+        with _silence_rdkit():
+            mol = Chem.MolFromSmiles(cleaned)
+    except Exception:
+        return False
+    return mol is not None and mol.GetNumAtoms() > 0
+
+
+def _is_headerless_delimited_file(content: bytes, delimiter: str) -> bool:
+    """Detect whether a delimited text file has no header row.
+
+    Returns True only when the file's first data column is unambiguously
+    SMILES data rather than a column name. To avoid misclassifying a
+    chemistry-like header (e.g. a single row named ``CO``), both the first
+    AND second non-empty lines' leading cells must parse as valid SMILES.
+    Files with a single non-empty line fall back to the first-line check.
+
+    Args:
+        content: Raw file bytes.
+        delimiter: Detected column delimiter.
+
+    Returns:
+        True if the file should be read with ``header=None``.
+    """
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        try:
+            text = content.decode("latin-1")
+        except UnicodeDecodeError:
+            return False
+
+    non_empty = [line for line in text.splitlines() if line.strip()]
+    if not non_empty:
+        return False
+
+    first_cell = non_empty[0].split(delimiter)[0].strip()
+    if not _looks_like_smiles_value(first_cell):
+        return False
+
+    if len(non_empty) == 1:
+        return True
+
+    second_cell = non_empty[1].split(delimiter)[0].strip()
+    return _looks_like_smiles_value(second_cell)
+
+
+@dataclass
+class _DelimitedFileInfo:
+    """Shape information about a delimited text file used by the parser helpers."""
+
+    delimiter: str
+    is_headerless: bool
+    columns: List[str]
+    read_kwargs: Dict[str, Any]
+
+
+def _inspect_delimited_file(content: bytes) -> _DelimitedFileInfo:
+    """Inspect a delimited text file to determine delimiter, header mode, columns.
+
+    Produces the ``read_kwargs`` a subsequent ``pandas.read_csv`` call must use
+    to parse the file consistently with the detected shape. For headerless
+    files, column names are synthesized so downstream consumers always see a
+    ``SMILES`` column in position 0.
+    """
+    delimiter = _detect_delimiter(content)
+    is_headerless = _is_headerless_delimited_file(content, delimiter)
+
+    base_kwargs: Dict[str, Any] = {
+        "sep": delimiter,
+        "dtype": str,
+        "na_filter": False,
+    }
+
+    if is_headerless:
+        probe = pd.read_csv(
+            io.BytesIO(content),
+            nrows=1,
+            header=None,
+            **base_kwargs,
+        )
+        n_cols = len(probe.columns)
+        synthetic = ["SMILES"] + [f"col_{i}" for i in range(1, n_cols)]
+        read_kwargs = {**base_kwargs, "header": None, "names": synthetic}
+        return _DelimitedFileInfo(
+            delimiter=delimiter,
+            is_headerless=True,
+            columns=synthetic,
+            read_kwargs=read_kwargs,
+        )
+
+    header_probe = pd.read_csv(io.BytesIO(content), nrows=0, **base_kwargs)
+    return _DelimitedFileInfo(
+        delimiter=delimiter,
+        is_headerless=False,
+        columns=header_probe.columns.tolist(),
+        read_kwargs=base_kwargs,
+    )
+
+
+def _match_column_case_insensitive(columns: List[str], target: str) -> Optional[str]:
+    """Find a column by case-insensitive exact-name match, or None."""
+    lowered = target.lower()
+    for col in columns:
+        if str(col).lower() == lowered:
+            return col
+    return None
+
+
+_NAME_COLUMN_CANDIDATES: Tuple[str, ...] = (
+    "Name",
+    "name",
+    "NAME",
+    "ID",
+    "id",
+    "Compound",
+    "compound",
+    "Molecule",
+    "molecule",
+    "Title",
+    "title",
+)
+
+
+def _auto_detect_name_column(columns: List[str]) -> Optional[str]:
+    """Pick a likely name/ID column from a list of columns, or None."""
+    for candidate in _NAME_COLUMN_CANDIDATES:
+        if candidate in columns:
+            return candidate
+    return None
+
+
+def _peek_first_row_cells(content: bytes, delimiter: str) -> List[str]:
+    """Return the cells of the first non-empty line, split by ``delimiter``.
+
+    Used to map user-supplied column selections (which the frontend derives
+    from the first row of a headerless file) to synthesized column positions.
+    """
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        try:
+            text = content.decode("latin-1")
+        except UnicodeDecodeError:
+            return []
+
+    for line in text.splitlines():
+        if line.strip():
+            return [cell.strip() for cell in line.split(delimiter)]
+    return []
+
+
+def _resolve_column_for_headerless(
+    requested: str,
+    synthesized_columns: List[str],
+    first_row_cells: List[str],
+) -> Optional[str]:
+    """Map a user-supplied column name to a synthesized column for headerless files.
+
+    The frontend's local column detector treats the first data row as
+    column headers, so it shows the user cells like ``CCO`` or ``ethanol``
+    as column names. The backend synthesizes ``SMILES`` / ``col_N``. When
+    the file is headerless, we accept the user's selection if it matches
+    either the synthesized name or the first-row cell at that same position.
+    """
+    if not requested:
+        return None
+    req = requested.strip().lower()
+    for idx, synth in enumerate(synthesized_columns):
+        if req == synth.lower():
+            return synth
+        if idx < len(first_row_cells) and req == first_row_cells[idx].lower():
+            return synth
+    return None
 
 
 def _validate_smiles_format(smiles: str) -> Tuple[bool, Optional[str]]:
@@ -392,9 +651,7 @@ def parse_sdf(file_content: bytes, max_file_size_mb: int = 500) -> List[Molecule
                     try:
                         prop_value = mol.GetProp(prop_name)
                         # Sanitize property name and value
-                        safe_name = _sanitize_string(
-                            prop_name, max_length=MAX_COLUMN_NAME_LENGTH
-                        )
+                        safe_name = _sanitize_string(prop_name, max_length=MAX_COLUMN_NAME_LENGTH)
                         if _validate_column_name(safe_name):
                             properties[safe_name] = _sanitize_string(prop_value)
                     except Exception:
@@ -430,7 +687,11 @@ def parse_csv(
     """
     Parse a CSV/TSV/TXT file into a list of molecule data.
 
-    Automatically detects whether the file uses comma or tab delimiters.
+    Automatically detects:
+    - Whether the file uses comma or tab delimiters.
+    - Whether the file has a header row, by probing the first two rows with
+      RDKit. Headerless files have a ``SMILES`` column name synthesized
+      so downstream callers need no special handling.
 
     Args:
         file_content: Raw bytes of the delimited text file
@@ -454,57 +715,47 @@ def parse_csv(
             f"File too large: {file_size_mb:.1f}MB exceeds limit of {max_file_size_mb}MB"
         )
 
-    # Detect delimiter (comma or tab)
-    delimiter = _detect_delimiter(file_content)
-
-    # First, read just the header to find column names
     try:
-        df_header = pd.read_csv(io.BytesIO(file_content), nrows=0, sep=delimiter)
-        all_columns = df_header.columns.tolist()
-    except Exception as e:
-        raise ValueError(f"Failed to parse CSV file: {str(e)[:200]}")
+        info = _inspect_delimited_file(file_content)
+    except Exception as exc:
+        raise ValueError(f"Failed to parse CSV file: {str(exc)[:200]}")
+
+    all_columns = info.columns
 
     # Security: Validate column count
     if len(all_columns) > 1000:
         raise ValueError("Too many columns in CSV (maximum 1000)")
 
-    # Check for SMILES column (case-insensitive search)
-    smiles_col_actual = None
-    for col in all_columns:
-        if col.lower() == smiles_column.lower():
-            smiles_col_actual = col
-            break
-
+    smiles_col_actual = _match_column_case_insensitive(all_columns, smiles_column)
+    if smiles_col_actual is None and info.is_headerless:
+        # The frontend's local column detector reads the first data row of a
+        # headerless file as column names, so the user's ``smiles_column`` can
+        # arrive as e.g. ``"CCO"`` instead of the synthesized ``"SMILES"``.
+        # Map the user's selection to the synthesized column at the same
+        # position in the first data row.
+        first_row_cells = _peek_first_row_cells(file_content, info.delimiter)
+        smiles_col_actual = _resolve_column_for_headerless(
+            smiles_column, all_columns, first_row_cells
+        )
     if smiles_col_actual is None:
         raise ValueError(f"SMILES column '{smiles_column}' not found in CSV")
 
-    # Determine name column
-    name_col_actual = None
+    # Determine name column. Honour the user's explicit ``name_column`` first;
+    # accept first-row-cell aliasing for headerless files the same way we do
+    # for the SMILES column. For headered files without an explicit selection,
+    # fall back to the keyword-based auto-detection.
+    name_col_actual: Optional[str] = None
     if name_column:
-        for col in all_columns:
-            if col.lower() == name_column.lower():
-                name_col_actual = col
-                break
-    else:
-        # Try to auto-detect name column
-        for candidate in [
-            "Name",
-            "name",
-            "NAME",
-            "ID",
-            "id",
-            "Compound",
-            "compound",
-            "Molecule",
-            "molecule",
-            "Title",
-            "title",
-        ]:
-            if candidate in all_columns:
-                name_col_actual = candidate
-                break
+        name_col_actual = _match_column_case_insensitive(all_columns, name_column)
+        if name_col_actual is None and info.is_headerless:
+            first_row_cells = _peek_first_row_cells(file_content, info.delimiter)
+            name_col_actual = _resolve_column_for_headerless(
+                name_column, all_columns, first_row_cells
+            )
+    elif not info.is_headerless:
+        name_col_actual = _auto_detect_name_column(all_columns)
 
-    # Only read the columns we need (much faster for files with many columns)
+    # Read only the columns we need (much faster for wide files)
     cols_to_read = [smiles_col_actual]
     if name_col_actual:
         cols_to_read.append(name_col_actual)
@@ -513,18 +764,15 @@ def parse_csv(
         df = pd.read_csv(
             io.BytesIO(file_content),
             usecols=cols_to_read,
-            dtype=str,
-            na_filter=False,
-            sep=delimiter,
+            **info.read_kwargs,
         )
-    except Exception as e:
-        raise ValueError(f"Failed to parse CSV file: {str(e)[:200]}")
+    except Exception as exc:
+        raise ValueError(f"Failed to parse CSV file: {str(exc)[:200]}")
 
-    molecules = []
+    molecules: List[MoleculeData] = []
     for idx, row in df.iterrows():
         smiles = str(row[smiles_col_actual]).strip()
 
-        # Validate SMILES format
         is_valid, error_msg = _validate_smiles_format(smiles)
         if not is_valid:
             molecules.append(
@@ -537,7 +785,6 @@ def parse_csv(
             )
             continue
 
-        # Get name with sanitization
         if name_col_actual and row[name_col_actual]:
             name = _sanitize_string(str(row[name_col_actual]).strip(), max_length=256)
         else:
@@ -548,11 +795,27 @@ def parse_csv(
                 smiles=smiles,
                 name=name,
                 index=idx,
-                properties={},  # No extra properties needed for batch processing
+                properties={},
             )
         )
 
     return molecules
+
+
+def _count_file_lines(content: bytes) -> int:
+    """Count physical lines in a byte buffer, tolerant of CRLF/LF/CR endings.
+
+    ``content.count(b"\\n")`` alone misses old-Mac CR-only files. Using the
+    larger of LF-count and CR-count gives the correct line total for all
+    three common line-ending styles.
+    """
+    lf = content.count(b"\n")
+    cr = content.count(b"\r")
+    total = max(lf, cr)
+    # Files that end without a trailing terminator still contain that last line
+    if content and not content.endswith((b"\n", b"\r")):
+        total += 1
+    return max(total, 0)
 
 
 def detect_csv_columns(
@@ -562,7 +825,10 @@ def detect_csv_columns(
     """
     Detect column names in a delimited text file for user selection.
 
-    Automatically detects whether the file uses comma or tab delimiters.
+    Automatically detects:
+    - Whether the file uses comma or tab delimiters.
+    - Whether the file has a header row. For headerless files a synthetic
+      ``SMILES`` column is surfaced so the user sees a consistent choice.
 
     Args:
         file_content: Raw bytes of the delimited text file
@@ -581,22 +847,35 @@ def detect_csv_columns(
             f"File too large: {file_size_mb:.1f}MB exceeds limit of {max_file_size_mb}MB"
         )
 
-    # Detect delimiter (comma or tab)
-    delimiter = _detect_delimiter(file_content)
+    try:
+        info = _inspect_delimited_file(file_content)
+    except ValueError:
+        raise
+    except Exception as exc:
+        logger.error(f"Error detecting CSV columns: {exc}")
+        raise ValueError(f"Failed to read CSV file: {str(exc)[:100]}")
 
     try:
-        # Read only first few rows for column detection
         df_preview = pd.read_csv(
-            io.BytesIO(file_content), nrows=5, dtype=str, sep=delimiter
+            io.BytesIO(file_content),
+            nrows=5,
+            **info.read_kwargs,
         )
-        columns = [
-            col for col in df_preview.columns.tolist() if _validate_column_name(col)
-        ]
+    except ValueError:
+        raise
+    except Exception as exc:
+        logger.error(f"Error reading CSV preview: {exc}")
+        raise ValueError(f"Failed to read CSV file: {str(exc)[:100]}")
 
-        if not columns:
-            raise ValueError("No valid columns found in CSV")
+    columns = [col for col in info.columns if _validate_column_name(col)]
+    if not columns:
+        raise ValueError("No valid columns found in CSV")
 
-        # Try to detect SMILES column
+    # Suggest SMILES column. For headerless files the synthesized ``SMILES``
+    # column is always position 0 and always the right answer.
+    if info.is_headerless:
+        suggested_smiles: Optional[str] = "SMILES" if "SMILES" in columns else None
+    else:
         suggested_smiles = None
         smiles_keywords = [
             "smiles",
@@ -606,7 +885,7 @@ def detect_csv_columns(
             "structure",
         ]
         for col in columns:
-            col_lower = col.lower()
+            col_lower = str(col).lower()
             for keyword in smiles_keywords:
                 if keyword in col_lower:
                     suggested_smiles = col
@@ -614,14 +893,15 @@ def detect_csv_columns(
             if suggested_smiles:
                 break
 
-        # Try to detect Name/ID column
-        suggested_name = None
+    # Suggest name/ID column only for headered files; synthesized ``col_N``
+    # labels from headerless parsing carry no semantic meaning.
+    suggested_name: Optional[str] = None
+    if not info.is_headerless:
         name_keywords = ["name", "id", "compound", "molecule", "title", "identifier"]
         for col in columns:
-            col_lower = col.lower()
-            # Skip if it's the SMILES column
             if col == suggested_smiles:
                 continue
+            col_lower = str(col).lower()
             for keyword in name_keywords:
                 if keyword in col_lower:
                     suggested_name = col
@@ -629,49 +909,37 @@ def detect_csv_columns(
             if suggested_name:
                 break
 
-        # Get sample values for each column (first non-empty value)
-        column_samples = {}
-        for col in columns[:20]:  # Limit to first 20 columns for preview
-            for val in df_preview[col]:
-                if val and str(val).strip():
-                    column_samples[col] = _sanitize_string(str(val), max_length=100)
-                    break
+    # First non-empty sample value per column (capped to first 20 columns)
+    column_samples: Dict[str, str] = {}
+    for col in columns[:20]:
+        for val in df_preview[col]:
+            if val and str(val).strip():
+                column_samples[col] = _sanitize_string(str(val), max_length=100)
+                break
 
-        # Estimate row count from file size (fast, no full file read)
-        # For column detection, an estimate is sufficient
-        # Average row size varies, but ~200 bytes per row is reasonable for CSV with SMILES
-        if file_size_mb < 1:
-            # For small files, do a quick count
-            try:
-                line_count = file_content.count(b"\n")
-                row_count = max(1, line_count - 1)  # Subtract header
-            except Exception:
+    # Row count estimate. Subtract the header row only when the file has one.
+    header_offset = 0 if info.is_headerless else 1
+    if file_size_mb < 1:
+        line_count = _count_file_lines(file_content)
+        row_count = max(1, line_count - header_offset)
+    else:
+        try:
+            sample_size = min(102400, len(file_content))
+            sample_bytes = file_content[:sample_size]
+            lines_in_sample = _count_file_lines(sample_bytes)
+            if lines_in_sample > 1:
+                avg_line_length = sample_size / lines_in_sample
+                row_count = max(1, int(len(file_content) / avg_line_length) - header_offset)
+            else:
                 row_count = max(1, int(file_size_mb * 5000))
-        else:
-            # For larger files, estimate based on sample
-            try:
-                # Sample first 100KB to estimate average line length
-                sample_size = min(102400, len(file_content))
-                sample = file_content[:sample_size]
-                lines_in_sample = sample.count(b"\n")
-                if lines_in_sample > 1:
-                    avg_line_length = sample_size / lines_in_sample
-                    row_count = max(1, int(len(file_content) / avg_line_length) - 1)
-                else:
-                    row_count = max(1, int(file_size_mb * 5000))
-            except Exception:
-                row_count = max(1, int(file_size_mb * 5000))
+        except Exception:
+            row_count = max(1, int(file_size_mb * 5000))
 
-        return {
-            "columns": columns,
-            "suggested_smiles": suggested_smiles,
-            "suggested_name": suggested_name,
-            "column_samples": column_samples,
-            "row_count_estimate": row_count,
-            "file_size_mb": round(file_size_mb, 2),
-        }
-    except ValueError:
-        raise
-    except Exception as e:
-        logger.error(f"Error detecting CSV columns: {e}")
-        raise ValueError(f"Failed to read CSV file: {str(e)[:100]}")
+    return {
+        "columns": columns,
+        "suggested_smiles": suggested_smiles,
+        "suggested_name": suggested_name,
+        "column_samples": column_samples,
+        "row_count_estimate": row_count,
+        "file_size_mb": round(file_size_mb, 2),
+    }

--- a/backend/app/services/dataset_intelligence/batch_processor.py
+++ b/backend/app/services/dataset_intelligence/batch_processor.py
@@ -35,8 +35,13 @@ logger = logging.getLogger(__name__)
 
 # Heuristic column names for SMILES detection (case-insensitive)
 _SMILES_COLUMN_NAMES = {
-    "smiles", "smi", "canonical_smiles", "isomeric_smiles",
-    "structure", "input_smiles", "mol_smiles",
+    "smiles",
+    "smi",
+    "canonical_smiles",
+    "isomeric_smiles",
+    "structure",
+    "input_smiles",
+    "mol_smiles",
 }
 
 
@@ -69,6 +74,10 @@ def _parse_csv_full(file_path: str, smiles_column: str | None) -> tuple[list[dic
     this reads ALL columns so property distributions and contradictory
     label detection have access to the full data (Pitfall 9).
 
+    Handles headerless files by delegating to the shared ``file_parser``
+    headerless-detection helpers, so a single-column TSV with just SMILES
+    per line parses the same way as a standard headered CSV.
+
     Args:
         file_path: Path to the CSV file on disk.
         smiles_column: Explicit SMILES column name, or None for auto-detect.
@@ -76,29 +85,25 @@ def _parse_csv_full(file_path: str, smiles_column: str | None) -> tuple[list[dic
     Returns:
         Tuple of (molecule list, column names).
     """
-    # Auto-detect delimiter (handles tab-separated files with .csv extension)
-    with open(file_path, "r", encoding="utf-8", errors="replace") as fh:
-        sample = fh.read(8192)
-    import csv
-    try:
-        dialect = csv.Sniffer().sniff(sample, delimiters=",\t;|")
-        sep = dialect.delimiter
-    except csv.Error:
-        sep = ","
-    df = pd.read_csv(file_path, sep=sep, dtype=str, na_filter=False)
+    from app.services.batch.file_parser import _inspect_delimited_file
+
+    with open(file_path, "rb") as fh:
+        content = fh.read()
+
+    info = _inspect_delimited_file(content)
+    df = pd.read_csv(file_path, **info.read_kwargs)
     columns = df.columns.tolist()
 
-    # Determine SMILES column
+    # Determine SMILES column. For headerless files ``_inspect_delimited_file``
+    # has synthesized the name ``SMILES`` at position 0.
     smi_col = smiles_column
     if smi_col is None:
-        smi_col = _detect_smiles_column(columns)
+        smi_col = "SMILES" if info.is_headerless else _detect_smiles_column(columns)
     if smi_col is None:
         raise ValueError(
-            "Could not detect SMILES column. "
-            "Please specify the smiles_column parameter."
+            "Could not detect SMILES column. Please specify the smiles_column parameter."
         )
 
-    # Verify column exists (case-insensitive)
     actual_col = None
     for col in columns:
         if col.lower() == smi_col.lower():
@@ -124,13 +129,15 @@ def _parse_csv_full(file_path: str, smiles_column: str | None) -> tuple[list[dic
                     pass
 
         properties = {col: str(row[col]) for col in columns if col != actual_col}
-        molecules.append({
-            "index": int(idx),
-            "smiles": smiles,
-            "mol": mol,
-            "inchikey": ik,
-            "properties": properties,
-        })
+        molecules.append(
+            {
+                "index": int(idx),
+                "smiles": smiles,
+                "mol": mol,
+                "inchikey": ik,
+                "properties": properties,
+            }
+        )
 
     return molecules, columns
 
@@ -165,13 +172,15 @@ def _parse_sdf_full(file_path: str) -> tuple[list[dict], list[str]]:
 
         props = dict(mol_data.properties)
         all_prop_names.update(props.keys())
-        molecules.append({
-            "index": mol_data.index,
-            "smiles": smiles,
-            "mol": mol,
-            "inchikey": ik,
-            "properties": props,
-        })
+        molecules.append(
+            {
+                "index": mol_data.index,
+                "smiles": smiles,
+                "mol": mol,
+                "inchikey": ik,
+                "properties": props,
+            }
+        )
 
     columns = ["SMILES"] + sorted(all_prop_names)
     return molecules, columns
@@ -237,19 +246,24 @@ def process_dataset_audit(
         ConnectionManager subscribes to) AND stores metadata in
         ``dataset:meta:{job_id}`` for the polling status endpoint.
         """
-        msg = json.dumps({
-            "job_id": job_id,
-            "status": "processing",
-            "progress": round(pct, 1),
-            "current_stage": stage,
-        })
+        msg = json.dumps(
+            {
+                "job_id": job_id,
+                "status": "processing",
+                "progress": round(pct, 1),
+                "current_stage": stage,
+            }
+        )
         try:
             r.publish(f"batch:progress:{job_id}", msg)
-            r.hset(f"dataset:meta:{job_id}", mapping={
-                "status": "processing",
-                "progress": str(round(pct, 1)),
-                "current_stage": stage,
-            })
+            r.hset(
+                f"dataset:meta:{job_id}",
+                mapping={
+                    "status": "processing",
+                    "progress": str(round(pct, 1)),
+                    "current_stage": stage,
+                },
+            )
         except Exception:
             logger.warning("Failed to publish progress for dataset job %s", job_id)
 
@@ -326,9 +340,7 @@ def process_dataset_audit(
 
         contradictions: list[dict] = []
         if activity_column:
-            contradictions = detect_contradictory_labels(
-                molecules, activity_column
-            )
+            contradictions = detect_contradictory_labels(molecules, activity_column)
 
         publish_progress("contradictory_labels", 85.0)
 
@@ -348,9 +360,7 @@ def process_dataset_audit(
             "sha256_hash": sha256_hash,
         }
 
-        curation_report = build_curation_report(
-            health_result, file_metadata, contradictions
-        )
+        curation_report = build_curation_report(health_result, file_metadata, contradictions)
         curated_rows = build_curated_csv_rows(molecules, health_result)
 
         publish_progress("building_report", 95.0)
@@ -437,27 +447,34 @@ def process_dataset_audit(
         )
 
         # Update metadata to complete
-        r.hset(f"dataset:meta:{job_id}", mapping={
-            "status": "complete",
-            "progress": "100",
-            "current_stage": "",
-        })
+        r.hset(
+            f"dataset:meta:{job_id}",
+            mapping={
+                "status": "complete",
+                "progress": "100",
+                "current_stage": "",
+            },
+        )
         r.expire(f"dataset:meta:{job_id}", settings.BATCH_RESULT_TTL)
 
         # Publish final progress to the shared ConnectionManager channel
         r.publish(
             f"batch:progress:{job_id}",
-            json.dumps({
-                "job_id": job_id,
-                "status": "complete",
-                "progress": 100,
-                "current_stage": None,
-            }),
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "status": "complete",
+                    "progress": 100,
+                    "current_stage": None,
+                }
+            ),
         )
 
         logger.info(
             "Dataset audit complete for job %s: %d molecules, score=%.1f",
-            job_id, health_result.molecule_count, health_result.overall_score,
+            job_id,
+            health_result.molecule_count,
+            health_result.overall_score,
         )
 
         return {"job_id": job_id, "status": "complete"}
@@ -467,20 +484,25 @@ def process_dataset_audit(
 
         # Update metadata to error
         try:
-            r.hset(f"dataset:meta:{job_id}", mapping={
-                "status": "error",
-                "progress": "0",
-                "current_stage": "",
-                "error": str(exc)[:500],
-            })
+            r.hset(
+                f"dataset:meta:{job_id}",
+                mapping={
+                    "status": "error",
+                    "progress": "0",
+                    "current_stage": "",
+                    "error": str(exc)[:500],
+                },
+            )
             r.expire(f"dataset:meta:{job_id}", 3600)
             r.publish(
                 f"batch:progress:{job_id}",
-                json.dumps({
-                    "job_id": job_id,
-                    "status": "error",
-                    "error": str(exc)[:500],
-                }),
+                json.dumps(
+                    {
+                        "job_id": job_id,
+                        "status": "error",
+                        "error": str(exc)[:500],
+                    }
+                ),
             )
         except Exception:
             logger.warning("Failed to publish error status for dataset job %s", job_id)

--- a/backend/tests/test_batch/test_file_parser.py
+++ b/backend/tests/test_batch/test_file_parser.py
@@ -5,9 +5,12 @@ Tests for batch file parsing (SDF and CSV).
 import pytest
 
 from app.services.batch.file_parser import (
+    _is_headerless_delimited_file,
+    _looks_like_smiles_value,
     detect_csv_columns,
     parse_csv,
     parse_sdf,
+    validate_file_content_type,
 )
 
 
@@ -161,10 +164,7 @@ CCO,Ethanol
         assert molecules[0].parse_error is None
         # Empty SMILES should have a parse error
         assert molecules[1].parse_error is not None
-        assert (
-            "Empty" in molecules[1].parse_error
-            or "invalid" in molecules[1].parse_error.lower()
-        )
+        assert "Empty" in molecules[1].parse_error or "invalid" in molecules[1].parse_error.lower()
 
     def test_parse_csv_auto_detect_name_column(self):
         """Test auto-detection of name column."""
@@ -238,3 +238,217 @@ CC,Ethane
         result = detect_csv_columns(csv_content)
 
         assert result["row_count_estimate"] == 3
+
+
+class TestSingleColumnDelimitedFiles:
+    """Tests for single-column and headerless delimited text files.
+
+    Covers the bug where a TSV/CSV/TXT containing only SMILES (one per line,
+    with or without a header row) was incorrectly rejected by the batch
+    uploader with 'CSV file must use comma or tab delimiters'.
+    """
+
+    def test_single_column_tsv_with_header(self):
+        """A TSV with just a SMILES header and one SMILES per line parses."""
+        content = b"SMILES\nCCO\nCC(=O)O\nc1ccccc1\n"
+        molecules = parse_csv(content)
+
+        assert len(molecules) == 3
+        assert [m.smiles for m in molecules] == ["CCO", "CC(=O)O", "c1ccccc1"]
+        assert all(m.parse_error is None for m in molecules)
+
+    def test_single_column_csv_with_header(self):
+        """A CSV with just a SMILES header and one SMILES per line parses."""
+        content = b"SMILES\nCCO\nCC(=O)O\nc1ccccc1\n"
+        molecules = parse_csv(content)
+
+        assert len(molecules) == 3
+        assert [m.smiles for m in molecules] == ["CCO", "CC(=O)O", "c1ccccc1"]
+
+    def test_headerless_single_column(self):
+        """A file with no header, just SMILES per line, synthesizes SMILES column."""
+        content = b"CCO\nCC(=O)O\nc1ccccc1\nCCCCCC\n"
+        molecules = parse_csv(content)
+
+        assert len(molecules) == 4
+        assert [m.smiles for m in molecules] == [
+            "CCO",
+            "CC(=O)O",
+            "c1ccccc1",
+            "CCCCCC",
+        ]
+        assert all(m.parse_error is None for m in molecules)
+
+    def test_headerless_multi_column_tab(self):
+        """Headerless TSV with SMILES + extra column uses SMILES col_0."""
+        content = b"CCO\tethanol\nCC(=O)O\tacetic\nc1ccccc1\tbenzene\n"
+        molecules = parse_csv(content)
+
+        assert len(molecules) == 3
+        assert molecules[0].smiles == "CCO"
+        assert molecules[1].smiles == "CC(=O)O"
+        assert molecules[2].smiles == "c1ccccc1"
+
+    def test_crlf_line_endings(self):
+        """A file with Windows CRLF line endings parses correctly."""
+        content = b"SMILES\r\nCCO\r\nCC(=O)O\r\n"
+        molecules = parse_csv(content)
+
+        assert len(molecules) == 2
+        assert molecules[0].smiles == "CCO"
+        assert molecules[1].smiles == "CC(=O)O"
+
+    def test_headerless_crlf(self):
+        """Headerless file with CRLF endings still detected as headerless."""
+        content = b"CCO\r\nCC(=O)O\r\nc1ccccc1\r\n"
+        molecules = parse_csv(content)
+
+        assert len(molecules) == 3
+        assert molecules[0].smiles == "CCO"
+
+    def test_detect_columns_single_column_with_header(self):
+        """Column detection on single-column headered TSV."""
+        content = b"SMILES\nCCO\nCC(=O)O\n"
+        result = detect_csv_columns(content)
+
+        assert result["columns"] == ["SMILES"]
+        assert result["suggested_smiles"] == "SMILES"
+        assert result["column_samples"].get("SMILES") == "CCO"
+        assert result["row_count_estimate"] == 2
+
+    def test_detect_columns_headerless(self):
+        """Column detection synthesizes SMILES for a headerless file."""
+        content = b"CCO\nCC(=O)O\nc1ccccc1\n"
+        result = detect_csv_columns(content)
+
+        assert "SMILES" in result["columns"]
+        assert result["suggested_smiles"] == "SMILES"
+        # Row count should NOT subtract a non-existent header
+        assert result["row_count_estimate"] == 3
+
+    def test_headered_file_with_valid_smiles_column_is_not_headerless(self):
+        """Standard CSV with 'SMILES' header must not be misclassified."""
+        content = b"SMILES,Name\nCCO,ethanol\nCC(=O)O,acetic\n"
+        molecules = parse_csv(content)
+
+        assert len(molecules) == 2
+        assert molecules[0].smiles == "CCO"
+        assert molecules[0].name == "ethanol"
+
+    def test_headerless_detection_helper_positive(self):
+        """_is_headerless_delimited_file returns True for clear headerless data."""
+        assert _is_headerless_delimited_file(b"CCO\nCC(=O)O\nc1ccccc1\n", ",")
+
+    def test_headerless_detection_helper_rejects_header(self):
+        """_is_headerless_delimited_file returns False when first row is a header."""
+        assert not _is_headerless_delimited_file(b"SMILES\nCCO\nCC(=O)O\n", ",")
+        assert not _is_headerless_delimited_file(b"SMILES,Name\nCCO,ethanol\n", ",")
+
+    def test_headerless_detection_helper_requires_two_valid_rows(self):
+        """First row parseable alone isn't enough — need two to avoid false positives."""
+        # Second line is intentionally invalid — should NOT be classified headerless
+        assert not _is_headerless_delimited_file(b"CCO\nNOT-A-SMILES-!@#\n", ",")
+
+    def test_looks_like_smiles_rejects_header_keywords(self):
+        """Common column names must not be detected as SMILES even if RDKit parses them."""
+        # 'N' parses as nitrogen but is a common column-name letter
+        assert not _looks_like_smiles_value("smiles")
+        assert not _looks_like_smiles_value("SMILES")
+        assert not _looks_like_smiles_value("Name")
+        assert not _looks_like_smiles_value("mol")
+        assert not _looks_like_smiles_value("")
+
+    def test_looks_like_smiles_accepts_real_smiles(self):
+        """Valid SMILES strings are detected."""
+        assert _looks_like_smiles_value("CCO")
+        assert _looks_like_smiles_value("CC(=O)O")
+        assert _looks_like_smiles_value("c1ccccc1")
+
+    def test_looks_like_smiles_rejects_whitespace(self):
+        """SMILES never contain whitespace; reject anything that does."""
+        assert not _looks_like_smiles_value("C C O")
+        assert not _looks_like_smiles_value("CCO ethanol")
+
+    def test_headerless_user_selects_first_row_cell_as_smiles_column(self):
+        """Frontend shows first row as column names for headerless files. Users
+        pick e.g. ``CCO`` as the SMILES column; backend must accept that.
+        """
+        content = b"CCO\nCC(=O)O\nc1ccccc1\n"
+        # Simulate UI sending the first-row value as the column name
+        molecules = parse_csv(content, smiles_column="CCO")
+        assert len(molecules) == 3
+        assert molecules[0].smiles == "CCO"
+        assert molecules[1].smiles == "CC(=O)O"
+
+    def test_headerless_multi_column_user_picks_by_position(self):
+        """Headerless multi-column file: user's column selection is mapped by
+        position in the first data row, not by synthesized name."""
+        content = b"CCO\tethanol\nCC(=O)O\tacetic_acid\nc1ccccc1\tbenzene\n"
+        molecules = parse_csv(content, smiles_column="CCO", name_column="ethanol")
+        assert len(molecules) == 3
+        assert molecules[0].smiles == "CCO"
+        assert molecules[0].name == "ethanol"
+        assert molecules[1].name == "acetic_acid"
+
+    def test_headerless_user_picks_synthesized_name(self):
+        """The synthesized ``SMILES`` name must also be accepted directly."""
+        content = b"CCO\nCC(=O)O\n"
+        molecules = parse_csv(content, smiles_column="SMILES")
+        assert len(molecules) == 2
+        assert molecules[0].smiles == "CCO"
+
+
+class TestValidateFileContentType:
+    """Tests for the pre-parse content validator."""
+
+    def test_accepts_single_column_tsv(self):
+        """A TSV with only SMILES per line (no tabs) must be accepted."""
+        content = b"SMILES\nCCO\nCC(=O)O\n"
+        is_valid, err = validate_file_content_type(content, "csv", "data.tsv")
+        assert is_valid, f"Expected valid, got error: {err}"
+
+    def test_accepts_headerless_tsv(self):
+        """A headerless TSV with raw SMILES must be accepted."""
+        content = b"CCO\nCC(=O)O\nc1ccccc1\n"
+        is_valid, err = validate_file_content_type(content, "csv", "data.tsv")
+        assert is_valid, f"Expected valid, got error: {err}"
+
+    def test_accepts_standard_csv(self):
+        """Standard multi-column CSV still accepted (regression)."""
+        content = b"SMILES,Name\nCCO,ethanol\n"
+        is_valid, err = validate_file_content_type(content, "csv", "data.csv")
+        assert is_valid
+
+    def test_accepts_crlf(self):
+        """CRLF-terminated single-column file accepted."""
+        content = b"SMILES\r\nCCO\r\nCC(=O)O\r\n"
+        is_valid, err = validate_file_content_type(content, "csv", "data.tsv")
+        assert is_valid
+
+    def test_rejects_empty_file(self):
+        """Empty file is rejected."""
+        is_valid, err = validate_file_content_type(b"", "csv", "empty.csv")
+        assert not is_valid
+
+    def test_rejects_whitespace_only(self):
+        """File with only whitespace is rejected."""
+        is_valid, err = validate_file_content_type(b"\n\n   \n", "csv", "blank.csv")
+        assert not is_valid
+
+    def test_rejects_binary_content(self):
+        """Binary content (non-printable bytes) is rejected."""
+        content = b"SMILES\nCCO\n" + (b"\x01\x02\x03\x04" * 30)
+        is_valid, err = validate_file_content_type(content, "csv", "evil.csv")
+        assert not is_valid
+
+    def test_rejects_executable_disguise(self):
+        """Windows EXE pretending to be CSV is rejected."""
+        is_valid, err = validate_file_content_type(b"MZ\x90\x00" + b"payload", "csv", "fake.csv")
+        assert not is_valid
+
+    def test_rejects_script_injection(self):
+        """Script injection attempt is rejected."""
+        is_valid, err = validate_file_content_type(
+            b"SMILES\n<script>alert(1)</script>\n", "csv", "xss.csv"
+        )
+        assert not is_valid


### PR DESCRIPTION
A TSV/CSV/TXT containing only SMILES (one per line, no tabs or commas) was rejected by /batch/upload with "CSV file must use comma or tab delimiters". The validator was stricter than the parser: single-column files are legitimate input.

- Drop the header-must-contain-delimiter check from _validate_csv_content. Keep non-printable-byte, encoding, and suspicious-content checks — those are the real security signals. Use splitlines() for LF/CRLF/CR tolerance.
- Add RDKit-based headerless detection (_is_headerless_delimited_file) that requires the first AND second row's leading cells to parse as valid SMILES and not match a known column-name keyword. Synthesized "SMILES" column is surfaced so downstream callers need no special-casing.
- Share _inspect_delimited_file between parse_csv and detect_csv_columns so column detection and upload agree on file shape.
- Accept first-row-cell aliasing in parse_csv so a user selection of e.g. "CCO" from the frontend's local detector maps to synthesized column 0.
- Apply the same headerless handling to dataset_intelligence._parse_csv_full.

Verified end-to-end: direct API, 41 unit tests (24 new), and Playwright UI run covering headered TSV, headerless TSV, and standard CSV.