### PR TITLE
feat(skills): add ChemAudit Claude Code plugin with 8 agent skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "chemaudit",
+  "version": "1.0.0",
+  "description": "Chemical structure validation, QSAR-ready curation, structure filtering, dataset auditing, and cross-database integration tools for cheminformatics workflows. Bundles 8 skills that coordinate ChemAudit's REST API, MCP server, and CLI for single-molecule validation, batch processing, generative-chemistry filtering (REINVENT 4-compatible), dataset health auditing with contradictory-label detection, ChEMBL-compatible standardization with provenance, SMILES/InChI diagnostics, and lookups across PubChem, ChEMBL, COCONUT, Wikidata, and SureChEMBL.",
+  "author": {
+    "name": "Kohulan Rajan",
+    "email": "krajan@beilstein-institut.de"
+  },
+  "homepage": "https://github.com/Kohulan/ChemAudit",
+  "repository": "https://github.com/Kohulan/ChemAudit",
+  "license": "MIT",
+  "keywords": [
+    "chemistry",
+    "cheminformatics",
+    "drug-discovery",
+    "SMILES",
+    "validation",
+    "QSAR",
+    "machine-learning",
+    "REINVENT",
+    "PubChem",
+    "ChEMBL",
+    "claude-skill",
+    "claude-code",
+    "model-invoked"
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "chemaudit": {
+      "type": "http",
+      "url": "http://localhost:8001/mcp"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -498,6 +498,50 @@ Once connected, you can ask your AI assistant:
 
 ---
 
+## 🧠 Agent Skills
+
+ChemAudit ships as a **Claude Code plugin** with 8 domain skills that coordinate the API, MCP server, and CLI into workflow-aware guidance. Skills activate automatically when a user's request matches their trigger phrases — no manual invocation required.
+
+### Skills
+
+| Skill | Use when the user asks about… |
+|---|---|
+| **chemaudit-molecule-validation** | single-molecule validation, drug-likeness, deep checks, PAINS, ML-readiness |
+| **chemaudit-batch-validation** | CSV/SDF bulk processing, clustering, scaffold analysis, 9 export formats |
+| **chemaudit-qsar-ready** | ML-dataset curation, 10-step pipeline, InChIKey deduplication, QSAR-2D vs 3D |
+| **chemaudit-structure-filter** | generative-model output filtering, REINVENT 4 scoring, drug-like / lead-like / fragment-like funnel |
+| **chemaudit-dataset-intelligence** | dataset health scoring, contradictory bioactivity labels, dataset-version diffs |
+| **chemaudit-standardization** | ChEMBL-compatible standardization with per-stage provenance |
+| **chemaudit-diagnostics** | SMILES parse errors, InChI layer diff, round-trip lossiness, file pre-validation |
+| **chemaudit-database-integrations** | PubChem / ChEMBL / COCONUT / Wikidata / SureChEMBL lookups, identifier resolution (CAS, ChEMBL ID, names) |
+
+### Installation
+
+The repo includes a `.claude-plugin/plugin.json` and a root `.mcp.json` for zero-config MCP auto-discovery:
+
+```bash
+# Clone the repo
+git clone https://github.com/Kohulan/ChemAudit.git && cd ChemAudit
+
+# Start the stack — MCP server becomes available at :8001/mcp
+docker compose up -d
+
+# Open the directory in Claude Code — skills and MCP server auto-connect
+claude .
+```
+
+Skills live in [`skills/chemaudit-*/SKILL.md`](skills/) and are distributed via the plugin manifest. Each skill is under 5,000 words and uses Anthropic's [progressive disclosure](https://docs.claude.com/en/docs/claude-code/plugins) pattern — YAML frontmatter loaded into context, SKILL.md loaded on trigger, `references/` files loaded only when needed.
+
+### Example AI workflow
+
+With skills installed, users can say:
+
+> "Upload this CSV through QSAR-ready with tautomer canonicalization on, show me how many molecules changed InChIKey, and export the curated CSV"
+
+Claude recognizes the `chemaudit-qsar-ready` skill, calls `/qsar-ready/batch/upload` with the right config, polls via WebSocket, counts `inchikey_changed=true` entries, and downloads the curated CSV — all without the user specifying any endpoint names.
+
+---
+
 ## 🏗 Project Structure
 
 ```

--- a/skills/chemaudit-batch-validation/SKILL.md
+++ b/skills/chemaudit-batch-validation/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: chemaudit-batch-validation
+description: >
+  Process CSV, TSV, TXT, or SDF files of molecules through ChemAudit's batch
+  pipeline with Redis-backed progress tracking, on-demand analytics (scaffold,
+  chemical space, clustering, MMP, taxonomy, R-group), and nine export formats.
+  Use when user says "validate this file", "batch validation", "process these
+  molecules", "upload CSV of SMILES", "export results", "scaffold analysis",
+  "cluster compounds", "Butina clustering", or "PDF report for these molecules".
+  Deployment-profile-gated file size and molecule-count limits — query /config
+  first.
+license: MIT
+allowed-tools: "Bash(curl:*) Bash(python:*) Bash(jq:*)"
+compatibility: >
+  Requires a running ChemAudit instance with Redis and Celery workers
+  (docker compose up). WebSocket support requires the browser or a WS client.
+metadata:
+  author: Kohulan Rajan
+  version: 1.0.0
+  mcp-server: chemaudit
+  category: cheminformatics
+  tags: [batch-processing, chemistry, CSV, SDF, clustering, scaffold, analytics]
+---
+
+# ChemAudit Batch Validation
+
+## Overview
+
+File-in, file-out bulk validation with three phases:
+
+1. **Upload → Celery enqueue** — instant `job_id` response.
+2. **Processing** — per-molecule validation + optional scoring, safety, profiling, standardization. Progress via WebSocket or `/status` polling.
+3. **Analytics (opt-in)** — scaffold, chemical space, clustering, MMP, taxonomy, similarity search, R-group decomposition. Computed on demand after the base job completes.
+
+All state lives in Redis keyed by `job_id`. Session cookies scope access (one owner per job).
+
+## Deployment limits — check first
+
+```bash
+curl -sS http://localhost:8000/api/v1/config
+```
+
+Returns `{"limits": {"max_batch_size": N, "max_file_size_mb": M}, "deployment_profile": "medium"}`. Profiles (small/medium/large/xl/coconut) set these via `config/*.yml`.
+
+## Workflow
+
+### 1. CSV column detection (optional, CSV/TSV/TXT only)
+
+Before upload, probe a CSV for SMILES and Name columns:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/batch/detect-columns \
+  -F "file=@compounds.csv"
+```
+
+Returns `{columns, suggested_smiles, suggested_name, column_samples, row_count_estimate, file_size_mb}`.
+
+### 2. Upload
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/batch/upload \
+  -F "file=@compounds.csv" \
+  -F "smiles_column=SMILES" \
+  -F "name_column=Name" \
+  -F "include_extended_safety=false" \
+  -F "include_chembl_alerts=false" \
+  -F "include_standardization=true" \
+  -F "include_profiling=false" \
+  -F "include_safety_assessment=false" \
+  -F "profile_id=" \
+  -F "notification_email="
+```
+
+Accepts `.sdf`, `.csv`, `.tsv`, `.txt`. Response:
+
+```json
+{
+  "job_id": "9e3b2c1e-....",
+  "status": "pending",
+  "total_molecules": 450,
+  "message": "Job submitted. Processing 450 molecules."
+}
+```
+
+Form fields:
+- `smiles_column` — CSV only; defaults to `SMILES`.
+- `name_column` — CSV only; optional.
+- `include_extended_safety` — add NIH and ZINC catalogs.
+- `include_chembl_alerts` — add 7 ChEMBL pharma filter sets (BMS, Dundee, Glaxo, Inpharmatica, LINT, MLSMR, SureChEMBL).
+- `include_standardization` — run ChEMBL standardization pipeline per molecule.
+- `include_profiling` — PFI, #stars, Abbott bioavailability, CNS MPO.
+- `include_safety_assessment` — CYP, hERG, bRo5, REOS, complexity panel.
+- `profile_id` — scoring profile ID; adds profile desirability score per molecule.
+- `notification_email` — sends a completion email (validated server-side).
+
+### 3. Track progress
+
+**WebSocket (preferred):**
+
+```javascript
+const ws = new WebSocket(`ws://localhost:8000/ws/batch/${job_id}`);
+ws.onmessage = (e) => console.log(JSON.parse(e.data));
+// Send "ping" to keep alive; server replies "pong".
+```
+
+Messages: `{job_id, status, progress, processed, total, eta_seconds}`.
+
+**Polling:**
+
+```bash
+curl -sS http://localhost:8000/api/v1/batch/<job_id>/status
+```
+
+### 4. Paginated results
+
+```bash
+curl -sS "http://localhost:8000/api/v1/batch/<job_id>?page=1&page_size=50&status_filter=error&min_score=0&max_score=40"
+```
+
+Filters: `status_filter` (`success`/`error`), `min_score`/`max_score` (0–100), `sort_by` (index/name/smiles/score/qed/safety/status/issues), `sort_dir` (asc/desc), `issue_filter` (failed check name), `alert_filter` (catalog name).
+
+Stats-only endpoint (cheap, no results array):
+
+```bash
+curl -sS http://localhost:8000/api/v1/batch/<job_id>/stats
+```
+
+### 5. On-demand analytics
+
+Get current analytics status and any cached results:
+
+```bash
+curl -sS http://localhost:8000/api/v1/batch/<job_id>/analytics
+```
+
+Trigger a specific computation:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/analytics/scaffold
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/analytics/chemical_space \
+  -H 'Content-Type: application/json' -d '{"method": "tsne"}'
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/analytics/clustering \
+  -H 'Content-Type: application/json' -d '{"cutoff": 0.35}'
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/analytics/mmp \
+  -H 'Content-Type: application/json' -d '{"activity_column": "pIC50"}'
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/analytics/similarity_search \
+  -H 'Content-Type: application/json' -d '{"query_smiles": "CCO", "top_k": 20}'
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/analytics/rgroup \
+  -H 'Content-Type: application/json' -d '{"core_smarts": "c1ccccc1"}'
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/analytics/taxonomy
+```
+
+Supported analysis types: `scaffold`, `chemical_space`, `mmp`, `similarity_search`, `rgroup`, `clustering`, `taxonomy`.
+
+**Clustering cap**: Butina clustering is hard-capped at 1,000 molecules (D-06). Subsample or filter first on larger jobs.
+
+Triggering an analysis that's already cached returns `already_complete` unless params differ (e.g. different `method` for chemical_space or different `cutoff` for clustering — those trigger recompute).
+
+### 6. Pairwise MCS comparison
+
+Between any two molecules in the batch by index:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/mcs \
+  -H 'Content-Type: application/json' \
+  -d '{"index_a": 0, "index_b": 17}'
+```
+
+Returns MCS SMARTS, Tanimoto similarity, matched atom/bond counts, property deltas.
+
+### 7. Subset actions
+
+Apply an operation to a hand-picked subset from the UI or another filter pass:
+
+```bash
+# Revalidate — creates new batch with the chosen indices
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/subset/revalidate \
+  -H 'Content-Type: application/json' \
+  -d '{"indices": [0, 3, 17, 42]}'
+
+# Rescore with a profile — creates new batch or scores inline
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/subset/rescore \
+  -H 'Content-Type: application/json' \
+  -d '{"indices": [0, 3, 17], "profile_id": 4}'
+
+# Inline rescore (no Celery, sync response)
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/subset/score-inline \
+  -H 'Content-Type: application/json' \
+  -d '{"indices": [0, 3, 17], "profile_id": 4}'
+
+# Export just the subset
+curl -sS -X POST http://localhost:8000/api/v1/batch/<job_id>/subset/export \
+  -H 'Content-Type: application/json' \
+  -d '{"indices": [0, 3, 17], "format": "sdf"}' -o subset.sdf
+```
+
+### 8. Export — 9 formats
+
+```bash
+curl -sS "http://localhost:8000/api/v1/batch/<job_id>/export?format=excel&include_images=true&sheet_layout=multi" \
+  -o results.xlsx
+
+curl -sS "http://localhost:8000/api/v1/batch/<job_id>/export?format=pdf&include_audit=true&sections=validation_summary,score_distribution" \
+  -o report.pdf
+```
+
+Formats (details in `references/export-formats.md`):
+
+| Format | Content |
+|---|---|
+| `csv` | All validation, scoring, and alert columns |
+| `excel` | Multi-sheet XLSX, optional 2D images, conditional coloring |
+| `sdf` | MOL blocks with properties; `include_audit=true` for full audit |
+| `json` | Full result objects with nested metadata |
+| `pdf` | Professional report; charts, stats, images; section-selectable |
+| `fingerprint` | ZIP with Morgan/MACCS/RDKit fingerprints as CSV, .npy, .npz |
+| `dedup` | ZIP with deduplication summary and per-group annotated CSVs |
+| `scaffold` | CSV with Murcko scaffold SMILES and scaffold-group assignment |
+| `property_matrix` | ZIP with flat CSV + multi-sheet Excel of all properties |
+
+Filters: `score_min`, `score_max`, `status` (`success`/`error`/`warning`), `indices=0,1,5,23` (GET) or POST body `{"indices": [...]}` for large selections.
+
+### 9. Cancel
+
+```bash
+curl -sS -X DELETE http://localhost:8000/api/v1/batch/<job_id>
+```
+
+Already-completed results are retained.
+
+## Examples
+
+### Example 1 — "Upload compounds.csv, poll, export failures as SDF"
+
+1. `POST /api/v1/batch/upload` with the file → capture `job_id`.
+2. Poll `GET /api/v1/batch/<job_id>/status` until `status == "complete"`.
+3. `GET /api/v1/batch/<job_id>/export?format=sdf&status=error` → save to `failures.sdf`.
+
+### Example 2 — "Scaffold distribution for this library"
+
+1. Upload, wait for complete.
+2. `POST /api/v1/batch/<job_id>/analytics/scaffold`.
+3. Poll `GET /api/v1/batch/<job_id>/analytics` until the `scaffold` key moves to `status: complete`.
+4. Read `scaffold.groups[]` and render a Murcko-scaffold frequency chart.
+
+### Example 3 — "Cluster at Tanimoto 0.7 and export cluster centroids"
+
+1. Ensure the batch has ≤ 1,000 molecules.
+2. `POST /api/v1/batch/<job_id>/analytics/clustering` with `{"cutoff": 0.30}` (distance, not similarity — 0.30 distance ≈ 0.70 similarity).
+3. Read `clustering.clusters[]`; each contains `centroid_index`.
+4. Subset-export those indices as CSV.
+
+## Rate limits
+
+- `/batch/upload`: 3/minute.
+- `/batch/detect-columns`: 10/minute.
+- `/batch/<job_id>` (paginated results): 60/minute.
+- `/batch/<job_id>/status`, `/stats`, DELETE `/batch/<job_id>`: 10/minute.
+- `/batch/<job_id>/analytics` (status poll): 120/minute.
+- `/batch/<job_id>/analytics/<type>` (trigger): 10/minute.
+- `/batch/<job_id>/mcs`: 30/minute.
+- `/batch/<job_id>/subset/revalidate`, `/subset/rescore`, `/subset/export`: 10/minute.
+- `/batch/<job_id>/subset/score-inline`: 30/minute.
+- `/batch/<job_id>/export` (GET and POST): 30/minute.
+
+API key via `X-API-Key` raises the per-minute tier.
+
+## Troubleshooting
+
+### 400 "File too large" / 400 "File contains N molecules. Maximum allowed is M."
+
+Check `/api/v1/config` — deployment limits are profile-driven. Split the file or redeploy with a larger profile (`./deploy.sh large`).
+
+### 400 "No valid molecules found in file"
+
+CSV column wrong, or every row has a parse error. Run `/batch/detect-columns` first, or pre-validate with `/diagnostics/file-prevalidate` (see `chemaudit-diagnostics`).
+
+### 400 "Invalid file content. Please check the file format and column names."
+
+Malicious-content scan matched a pattern (script tags, macros). Legitimate hits are rare — audit-logged server-side. Sanitize the source file.
+
+### 400 "Invalid notification email address"
+
+Pattern-validated; must be a normal `user@domain.tld` under 254 chars.
+
+### 404 on `/batch/<job_id>` a few minutes after completion
+
+Results TTL in Redis is `BATCH_RESULT_TTL` (default 1 hour). Download exports before expiry or increase the TTL.
+
+### 400 "Clustering is limited to 1,000 molecules"
+
+D-06 hard cap. Filter (by score, alert, or scaffold) before triggering clustering.
+
+### WebSocket closes with code 4003 / 4029
+
+- 4003: session cookie doesn't own the job (uploaded anonymously in a different browser).
+- 4029: too many simultaneous WS connections for one job (`_WS_MAX_PER_JOB` = 10).
+
+### Analytics status stuck at `computing`
+
+The Celery worker crashed mid-task. Trigger the same analysis again — the idempotency guard resets `computing` to `queued` when params change; otherwise flush the status key manually.
+
+## Further reading
+
+- `references/export-formats.md` — exhaustive spec of all nine export formats.
+- `chemaudit-qsar-ready` — for ML-dataset curation pipelines on the same file input.
+- `chemaudit-structure-filter` — for generative-chemistry funnel filtering on a SMILES list.
+- `chemaudit-dataset-intelligence` — for dataset health auditing with activity columns.

--- a/skills/chemaudit-batch-validation/references/export-formats.md
+++ b/skills/chemaudit-batch-validation/references/export-formats.md
@@ -1,0 +1,161 @@
+# ChemAudit Batch Export Formats
+
+Nine export formats available at `GET /api/v1/batch/{job_id}/export?format=<fmt>` (or POST for large index selections).
+
+## Common filters
+
+All formats accept: `score_min`, `score_max`, `status` (`success`/`error`/`warning`), `indices` (comma-separated for GET, array body for POST).
+
+---
+
+## `csv`
+
+Flat CSV with one row per molecule. Columns include:
+
+- `index`, `name`, `smiles`, `canonical_smiles`, `inchikey`
+- `status`, `error`
+- Validation: `overall_score`, `issues` (semicolon-joined check names), `num_issues`
+- Scoring (when enabled at upload): `qed`, `sa_score`, `mw`, `logp`, `hbd`, `hba`, `tpsa`, `rotatable_bonds`, `num_aromatic_rings`, `fsp3`, `lipinski_passed`
+- Alerts (when enabled): `alert_pains`, `alert_brenk`, `alert_nih`, `alert_zinc`, `alert_count`
+- Standardization (when `include_standardization=true`): `standardized_smiles`, `std_changes`
+
+Media type: `text/csv`. Extension: `.csv`.
+
+---
+
+## `excel`
+
+Query params:
+- `include_images=true|false` — embed 2D depictions of each molecule (slower, larger files).
+- `sheet_layout=single|multi` — one sheet with everything, or one sheet per section (Validation / Scoring / Alerts / Standardization / Properties).
+
+Styling: conditional colouring on score columns (green ≥70, amber 40–69, red <40), frozen header row, column-width auto-fit.
+
+Media type: `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`. Extension: `.xlsx`.
+
+---
+
+## `sdf`
+
+MOL blocks concatenated with `$$$$` terminators. Each molecule has properties attached:
+
+- `<SMILES>`, `<InChIKey>`, `<Validation_Score>`, `<Issues>` (newline-joined)
+- `<QED>`, `<SA_Score>`, `<MW>`, `<LogP>`, `<TPSA>` (when scoring enabled)
+- `<PAINS_Alerts>`, `<BRENK_Alerts>`, etc. (when alerts enabled)
+
+Query param `include_audit=true` adds full JSON-serialized validation and scoring payloads as single-line properties for downstream parsing.
+
+Media type: `chemical/x-mdl-sdfile`. Extension: `.sdf`.
+
+---
+
+## `json`
+
+Newline-delimited array of full result objects. Structure per molecule:
+
+```json
+{
+  "index": 0,
+  "smiles": "...",
+  "name": null,
+  "status": "success",
+  "validation": {"overall_score": 87, "issues": [...], "all_checks": [...]},
+  "alerts": {...},
+  "scoring": {"druglikeness": {...}, "admet": {...}, "np_likeness": {...}},
+  "standardization": {...},
+  "profiling": {...},
+  "safety_assessment": {...}
+}
+```
+
+Includes everything the backend stored — the most faithful representation.
+
+Media type: `application/json`. Extension: `.json`.
+
+---
+
+## `pdf`
+
+Query params:
+- `sections=validation_summary,score_distribution,alert_breakdown,top_issues,property_histograms` — pick a subset. Default is all sections.
+- `include_audit=true` — add a per-molecule audit appendix.
+
+Contains:
+- Executive summary (counts, pass rate, processing time).
+- Score distribution histogram.
+- Alert breakdown bar chart by catalog.
+- Property histograms (MW, LogP, TPSA, QED, SA score).
+- Top-N failing-check frequency table.
+- Optional: per-molecule thumbnail cards with SMILES, score, issues.
+
+Media type: `application/pdf`. Extension: `.pdf`.
+
+---
+
+## `fingerprint`
+
+ZIP archive containing fingerprint vectors computed from the canonical SMILES:
+
+- `morgan_r2_2048.csv`, `morgan_r2_2048.npy`, `morgan_r2_2048.npz` — Morgan radius=2, 2048 bits.
+- `maccs.csv`, `maccs.npy`, `maccs.npz` — 166-bit MACCS keys.
+- `rdkit_default.csv`, `rdkit_default.npy`, `rdkit_default.npz` — RDKit path-based fingerprint.
+- `index.csv` — mapping row index → `smiles`, `inchikey`, `name`.
+
+`.csv` = human-readable one-row-per-molecule with bit string; `.npy` = dense NumPy; `.npz` = sparse CSR.
+
+Media type: `application/zip`. Extension: `.zip`.
+
+---
+
+## `dedup`
+
+ZIP with deduplication analysis keyed by InChIKey:
+
+- `summary.csv` — one row per unique InChIKey with cluster size and representative SMILES.
+- `duplicate_groups/<inchikey>.csv` — per-group CSV listing all rows, their original indices, and any property deltas.
+- `README.txt` — summary counts (input, unique, duplicates removed).
+
+Media type: `application/zip`. Extension: `.zip`.
+
+---
+
+## `scaffold`
+
+Single CSV with Murcko scaffold analysis:
+
+- Columns: `index`, `smiles`, `scaffold_smiles` (Murcko), `generic_scaffold_smiles` (carbon-only skeleton), `scaffold_group_id`, `scaffold_group_size`.
+- Molecules sharing the same Murcko scaffold receive the same `scaffold_group_id` (1-indexed, ordered by frequency).
+
+Media type: `text/csv`. Extension: `.csv`.
+
+---
+
+## `property_matrix`
+
+ZIP with molecule × property matrices:
+
+- `properties_flat.csv` — molecules as rows, every numeric property as a column.
+- `properties_multi.xlsx` — Excel with one sheet per property family (Physicochemical / Druglikeness / ADMET / Safety).
+- `schema.json` — column definitions (units, source, computation method).
+
+Media type: `application/zip`. Extension: `.zip`.
+
+---
+
+## Subset export (hand-picked indices)
+
+POST when indices would exceed URL length on GET:
+
+```bash
+curl -sS -X POST "http://localhost:8000/api/v1/batch/<job_id>/export?format=excel&include_images=true" \
+  -H 'Content-Type: application/json' \
+  -d '{"indices": [0, 3, 17, 42, 101, 303, ...]}' -o selected.xlsx
+```
+
+Also available as a dedicated endpoint:
+
+```bash
+curl -sS -X POST "http://localhost:8000/api/v1/batch/<job_id>/subset/export" \
+  -H 'Content-Type: application/json' \
+  -d '{"indices": [0, 3, 17], "format": "sdf"}' -o subset.sdf
+```

--- a/skills/chemaudit-database-integrations/SKILL.md
+++ b/skills/chemaudit-database-integrations/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: chemaudit-database-integrations
+description: >
+  Look up molecules across PubChem, ChEMBL, COCONUT, Wikidata, and SureChEMBL
+  patent databases, resolve chemical identifiers (CAS, ChEMBL ID, PubChem CID,
+  ChEBI, UNII, DrugBank, names), and run cross-database consistency checks. Use
+  when user says "look up in PubChem", "ChEMBL bioactivity", "natural product
+  search", "COCONUT lookup", "Wikidata lookup", "resolve CAS number", "resolve
+  ChEMBL ID", "cross-database check", "find this compound", "patent search",
+  "SureChEMBL", or "identifier resolution". Supports SMILES, InChI, InChIKey,
+  CAS, ChEMBL ID, PubChem CID, ChEBI, UNII, DrugBank ID, Wikipedia URL, and
+  compound names (OPSIN + PubChem fallback).
+license: MIT
+allowed-tools: "Bash(curl:*) Bash(python:*)"
+compatibility: >
+  Requires a running ChemAudit instance with outbound network access to PubChem,
+  ChEMBL, COCONUT, Wikidata, and SureChEMBL APIs.
+metadata:
+  author: Kohulan Rajan
+  version: 1.0.0
+  mcp-server: chemaudit
+  category: cheminformatics
+  tags: [PubChem, ChEMBL, COCONUT, Wikidata, identifier-resolution, databases, SureChEMBL]
+---
+
+# ChemAudit Database Integrations
+
+## Overview
+
+Five external-database lookups plus two cross-database tools:
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/v1/integrations/pubchem/lookup` | PubChem compound info (CID, IUPAC, synonyms, formula, MW) |
+| `POST /api/v1/integrations/chembl/bioactivity` | ChEMBL molecule + bioactivity records |
+| `POST /api/v1/integrations/coconut/lookup` | COCONUT natural-product database (>400K entries, organism, NP-likeness) |
+| `POST /api/v1/integrations/wikidata/lookup` | Wikidata via SPARQL (label, CAS, Wikipedia link) |
+| `POST /api/v1/integrations/surechembl/lookup` | SureChEMBL patent presence |
+| `POST /api/v1/integrations/compare` | Consistency check across PubChem + ChEMBL + COCONUT |
+| `POST /api/v1/resolve` | Universal identifier resolver for 11 identifier types |
+
+All lookup endpoints accept `{smiles: "...", inchikey: "..."}` — provide at least one. Identifier resolution accepts anything.
+
+## Workflow
+
+### 1. PubChem
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/integrations/pubchem/lookup \
+  -H 'Content-Type: application/json' \
+  -d '{"smiles": "CC(=O)Oc1ccccc1C(=O)O"}'
+```
+
+Response:
+
+```json
+{
+  "found": true,
+  "cid": 2244,
+  "iupac_name": "2-acetyloxybenzoic acid",
+  "molecular_formula": "C9H8O4",
+  "molecular_weight": 180.16,
+  "canonical_smiles": "CC(=O)OC1=CC=CC=C1C(=O)O",
+  "inchi": "InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)",
+  "inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+  "synonyms": ["aspirin", "acetylsalicylic acid", "2-acetoxybenzoic acid", ...],
+  "url": "https://pubchem.ncbi.nlm.nih.gov/compound/2244"
+}
+```
+
+### 2. ChEMBL bioactivity
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/integrations/chembl/bioactivity \
+  -H 'Content-Type: application/json' \
+  -d '{"inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"}'
+```
+
+Response:
+
+```json
+{
+  "found": true,
+  "chembl_id": "CHEMBL25",
+  "pref_name": "ASPIRIN",
+  "molecule_type": "Small molecule",
+  "max_phase": 4,
+  "molecular_formula": "C9H8O4",
+  "molecular_weight": 180.16,
+  "canonical_smiles": "...",
+  "inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+  "bioactivities": [
+    {
+      "target_chembl_id": "CHEMBL240",
+      "target_name": "Cyclooxygenase-1",
+      "target_type": "SINGLE PROTEIN",
+      "activity_type": "IC50",
+      "activity_value": 100.0,
+      "activity_unit": "nM",
+      "assay_chembl_id": "CHEMBL615139",
+      "document_chembl_id": "CHEMBL1127040"
+    }
+  ],
+  "bioactivity_count": 1234,
+  "url": "https://www.ebi.ac.uk/chembl/compound_report_card/CHEMBL25"
+}
+```
+
+`max_phase`: 0 (preclinical), 1-3 (clinical trials), 4 (approved).
+
+### 3. COCONUT natural products
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/integrations/coconut/lookup \
+  -H 'Content-Type: application/json' \
+  -d '{"smiles": "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"}'
+```
+
+Response:
+
+```json
+{
+  "found": true,
+  "coconut_id": "CNP0123456",
+  "name": "Caffeine",
+  "smiles": "CN1C=NC2=C1C(=O)N(C(=O)N2C)C",
+  "inchi": "...",
+  "inchikey": "RYYVLZVUVIJVGH-UHFFFAOYSA-N",
+  "molecular_formula": "C8H10N4O2",
+  "molecular_weight": 194.19,
+  "organism": "Coffea arabica",
+  "organism_type": "Plantae",
+  "nplikeness": 2.4,
+  "url": "https://coconut.naturalproducts.net/compounds/CNP0123456"
+}
+```
+
+### 4. Wikidata
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/integrations/wikidata/lookup \
+  -H 'Content-Type: application/json' \
+  -d '{"inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"}'
+```
+
+Returns label, canonical SMILES, InChIKey, CAS, formula, MW, and a Wikidata entity URL. SPARQL-based — typically slower than the other integrations. For a Wikipedia URL, use `/resolve` and read `cross_references.wikipedia_url`.
+
+### 5. SureChEMBL patent lookup
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/integrations/surechembl/lookup \
+  -H 'Content-Type: application/json' \
+  -d '{"inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"}'
+```
+
+Response:
+
+```json
+{
+  "found": true,
+  "schembl_id": "SCHEMBL25",
+  "url": "https://www.surechembl.org/chemical/SCHEMBL25",
+  "patent_count": 8432,
+  "source": "unichem+surechembl",
+  "smiles": "...",
+  "inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+  "molecular_weight": 180.16
+}
+```
+
+Binary present/absent with direct link; patent count populated when SureChEMBL's enrichment API is reachable.
+
+### 6. Cross-database comparison
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/integrations/compare \
+  -H 'Content-Type: application/json' \
+  -d '{"inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"}'
+```
+
+At least one of `smiles` or `inchikey` required. Runs PubChem, ChEMBL, COCONUT in parallel and aligns outputs.
+
+Response:
+
+```json
+{
+  "entries": [
+    {"database": "PubChem", "found": true, "canonical_smiles": "...", "inchikey": "...", "molecular_formula": "C9H8O4", "molecular_weight": 180.16, "name": "...", "url": "..."},
+    {"database": "ChEMBL", "found": true, ...},
+    {"database": "COCONUT", "found": false, ...}
+  ],
+  "comparisons": [
+    {"property_name": "canonical_smiles", "values": {"PubChem": "...", "ChEMBL": "..."}, "status": "agree", "detail": null},
+    {"property_name": "molecular_formula", "values": {"PubChem": "C9H8O4", "ChEMBL": "C9H8O4"}, "status": "agree", "detail": null},
+    {"property_name": "molecular_weight", "values": {"PubChem": "180.16", "ChEMBL": "180.159"}, "status": "minor_mismatch", "detail": "Difference within rounding tolerance"}
+  ],
+  "overall_verdict": "consistent_minor",
+  "summary": "All databases agree on structural identity; minor numeric differences within tolerance."
+}
+```
+
+Verdicts: `consistent`, `consistent_minor` (minor numeric differences), `inconsistent` (structural disagreement), `no_data` (no database found the compound).
+
+### 7. Universal identifier resolver
+
+Accepts **11 identifier types** and resolves to canonical SMILES with cross-references. Use this before any other lookup when you don't know the structural representation.
+
+```bash
+# CAS number
+curl -sS -X POST http://localhost:8000/api/v1/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "50-78-2", "identifier_type": "auto"}'
+
+# ChEMBL ID
+curl -sS -X POST http://localhost:8000/api/v1/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "CHEMBL25", "identifier_type": "auto"}'
+
+# PubChem CID
+curl -sS -X POST http://localhost:8000/api/v1/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "2244"}'
+
+# Compound name (OPSIN then PubChem)
+curl -sS -X POST http://localhost:8000/api/v1/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "acetylsalicylic acid"}'
+
+# Explicit type hint
+curl -sS -X POST http://localhost:8000/api/v1/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "DB00945", "identifier_type": "drugbank_id"}'
+```
+
+Supported types: `auto`, `smiles`, `inchi`, `inchikey`, `pubchem_cid`, `chembl_id`, `cas`, `drugbank_id`, `chebi_id`, `unii`, `wikipedia`, `name`.
+
+Response:
+
+```json
+{
+  "resolved": true,
+  "identifier_type_detected": "cas",
+  "canonical_smiles": "CC(=O)OC1=CC=CC=C1C(=O)O",
+  "inchi": "...",
+  "inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+  "molecular_formula": "C9H8O4",
+  "molecular_weight": 180.16,
+  "iupac_name": "2-acetyloxybenzoic acid",
+  "resolution_source": "pubchem",
+  "resolution_chain": ["cas", "pubchem_cid", "smiles"],
+  "cross_references": {
+    "pubchem_cid": 2244,
+    "chembl_id": "CHEMBL25",
+    "coconut_id": null,
+    "drugbank_id": "DB00945",
+    "chebi_id": "CHEBI:15365",
+    "unii": "R16CO5Y76E",
+    "cas": "50-78-2",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Aspirin",
+    "kegg_id": "C01405"
+  },
+  "confidence": "high"
+}
+```
+
+`resolution_chain` shows the UniChem/PubChem hops taken. `confidence` values: `high`, `medium`, `low`, `none`.
+
+## Examples
+
+### Example 1 — "Look up aspirin in all databases"
+
+1. Resolve the name first: `POST /resolve {"identifier": "aspirin"}` → get InChIKey.
+2. `POST /integrations/compare` with the InChIKey → one consolidated response covering PubChem, ChEMBL, COCONUT.
+3. For patent info: `POST /integrations/surechembl/lookup` separately.
+
+### Example 2 — "Convert this CAS number to SMILES"
+
+Just one call: `POST /resolve {"identifier": "50-78-2"}` → returns canonical SMILES plus UniChem cross-references to all other databases.
+
+### Example 3 — "Has anyone filed a patent on this compound?"
+
+`POST /integrations/surechembl/lookup {"inchikey": "..."}` → `found` tells you yes/no, `patent_count` tells you how many when enrichment API is available.
+
+### Example 4 — "Get all ChEMBL bioactivity records for aspirin and filter to IC50 values in nM"
+
+1. Resolve to ChEMBL ID or InChIKey.
+2. `POST /integrations/chembl/bioactivity {"inchikey": "..."}`.
+3. `bioactivities[]` has per-record `activity_type`, `activity_value`, `activity_unit`. Filter client-side to `activity_type=="IC50"` and `activity_unit=="nM"`.
+
+### Example 5 — "Are the PubChem and ChEMBL SMILES consistent for this compound?"
+
+`POST /integrations/compare` with the InChIKey → `comparisons[]` has per-property agreement status. `overall_verdict = "inconsistent"` means structures disagree — worth investigating.
+
+## Rate limits
+
+- `/integrations/pubchem/lookup`, `/chembl/bioactivity`, `/coconut/lookup`, `/wikidata/lookup`, `/surechembl/lookup`: 30/min.
+- `/integrations/compare`: 10/min.
+- `/resolve`: 30/min.
+
+Upstream APIs (PubChem, ChEMBL, etc.) have their own rate limits. Excessive queries may trigger temporary blocks from the upstream source — the ChemAudit service respects `Retry-After` headers where provided.
+
+## Troubleshooting
+
+### `found: false` but the compound definitely exists in PubChem
+
+Try the other identifier. Some compounds are indexed by InChIKey but not easily queried by SMILES (and vice-versa) due to tautomer/isomer normalization on the upstream side. If `/resolve` finds it via `name`, use the returned InChIKey.
+
+### `/resolve`: `resolved: false`, `confidence: "none"`
+
+None of the 11 resolvers matched. Common causes:
+- Typo in the identifier.
+- Non-standard format (e.g. CAS with no dashes).
+- Compound is too new and hasn't been indexed in UniChem yet.
+
+### Slow Wikidata responses
+
+SPARQL endpoint latency is highly variable. Wikidata is typically the slowest integration; consider skipping it for bulk workflows.
+
+### `/integrations/compare`: `verdict: "inconsistent"`
+
+Structural disagreement across databases — usually a charge state, tautomer, or salt-form difference. Read `comparisons[]` to isolate which property differs. Often resolved by standardizing first (`chemaudit-standardization`) and re-querying.
+
+### ChEMBL returns 0 bioactivities for a known drug
+
+Rare but possible when the compound is registered under a different ChEMBL ID (e.g. a salt form vs parent). `/resolve` the name, get the `chembl_id` from `cross_references`, then query directly.
+
+### SureChEMBL `found: false` but you know the compound is patented
+
+UniChem's SureChEMBL cross-reference isn't comprehensive. When found-by-UniChem misses, the SureChEMBL direct API may still succeed — the service attempts both in sequence.
+
+## Further reading
+
+- `chemaudit-molecule-validation` — validate the structure once resolved.
+- `chemaudit-standardization` — before cross-database comparison, standardize to reduce salt-form mismatches.
+- `chemaudit-dataset-intelligence` — for dataset-level cross-database consistency checks.

--- a/skills/chemaudit-dataset-intelligence/SKILL.md
+++ b/skills/chemaudit-dataset-intelligence/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: chemaudit-dataset-intelligence
+description: >
+  Audit dataset health with a Fourches-style 5-component score, detect
+  contradictory bioactivity labels across duplicates, compare two dataset
+  versions (added / removed / modified / unchanged), and generate curation
+  reports. Use when user says "audit this dataset", "dataset health score",
+  "contradictory labels", "duplicate activity conflict", "dataset diff",
+  "compare dataset versions", "curation report", "data quality check", or
+  "clean this dataset for ML". Accepts CSV and SDF with optional activity
+  columns.
+license: MIT
+allowed-tools: "Bash(curl:*) Bash(python:*)"
+compatibility: >
+  Requires a running ChemAudit instance with Celery workers for async audits.
+metadata:
+  author: Kohulan Rajan
+  version: 1.0.0
+  mcp-server: chemaudit
+  category: cheminformatics
+  tags: [dataset-curation, quality-control, ML-datasets, bioactivity, data-cleaning]
+---
+
+# ChemAudit Dataset Intelligence
+
+## Overview
+
+Whole-dataset auditing — operates on the file, not individual molecules. Four outputs:
+
+1. **Health audit** — composite 0-100 score with 5-component breakdown (Fourches 2010).
+2. **Contradictory labels** — duplicate InChIKeys with inconsistent activity values.
+3. **Dataset diff** — structural and property-level comparison between two uploads.
+4. **Curation report + curated CSV** — JSON report and downloadable cleaned CSV with appended diagnostic columns.
+
+## Health audit — 5 sub-scores (Fourches 2010)
+
+| Sub-score | Default weight | What it measures |
+|---|---|---|
+| `parsability` | 0.25 | Fraction of rows with a valid, parseable SMILES |
+| `stereo` | 0.15 | Fraction with defined stereocenters where chirality is expected |
+| `uniqueness` | 0.20 | 1 - (duplicates / total) by canonical InChIKey |
+| `alerts` | 0.20 | Fraction of molecules alert-free against the default catalogs |
+| `std_consistency` | 0.20 | Fraction agreeing across three standardization pipelines (RDKit vs ChEMBL vs minimal) on a sampled subset |
+
+Weights are customizable per audit; source of literature-backed defaults is `DEFAULT_WEIGHTS` in `frontend/src/types/dataset_intelligence.ts`.
+
+Overall score is the weighted sum × 100.
+
+## Contradictory labels — fold-difference thresholds
+
+For every InChIKey appearing ≥ 2 times with a numeric activity column, reports the max/min fold-difference. Threshold options: **3, 5, 10, 50, 100** (default: **10**). Entries above the threshold are flagged as contradictory.
+
+## Workflow
+
+### 1. Upload dataset
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/dataset/upload \
+  -F "file=@bioactivity.csv" \
+  -F "smiles_column=canonical_smiles" \
+  -F "activity_column=pIC50"
+```
+
+Both column names are optional — auto-detection runs if omitted. Accepts `.csv` and `.sdf`. Response:
+
+```json
+{
+  "job_id": "3f7a9b...",
+  "filename": "bioactivity.csv",
+  "file_type": "csv",
+  "status": "pending",
+  "message": "Dataset audit job submitted"
+}
+```
+
+### 2. Track progress
+
+WebSocket:
+
+```javascript
+const ws = new WebSocket(`ws://localhost:8000/ws/dataset/${job_id}`);
+```
+
+Poll:
+
+```bash
+curl -sS http://localhost:8000/api/v1/dataset/<job_id>/status
+```
+
+Response: `{job_id, status, progress, current_stage, eta_seconds}`. Stages: parse → health_audit → contradictions → standardization_sample → diff_ready.
+
+### 3. Fetch audit results
+
+```bash
+curl -sS http://localhost:8000/api/v1/dataset/<job_id>/results
+```
+
+While processing, returns HTTP 202 with `{job_id, status, message}`. When `complete`, returns:
+
+```json
+{
+  "job_id": "...",
+  "status": "complete",
+  "health_audit": {
+    "overall_score": 78.3,
+    "sub_scores": [
+      {"name": "parsability", "score": 0.985, "weight": 0.25, "count": 15, "total": 1000},
+      {"name": "stereo", "score": 0.62, "weight": 0.15, "count": 380, "total": 1000},
+      {"name": "uniqueness", "score": 0.93, "weight": 0.20, "count": 70, "total": 1000},
+      {"name": "alerts", "score": 0.81, "weight": 0.20, "count": 190, "total": 1000},
+      {"name": "std_consistency", "score": 0.88, "weight": 0.20, "count": 12, "total": 100}
+    ],
+    "weights": {"parsability": 0.25, "stereo": 0.15, "uniqueness": 0.20, "alerts": 0.20, "std_consistency": 0.20},
+    "molecule_count": 1000,
+    "issues": [
+      {"row_index": 42, "smiles": "C(C)(C)(C)(C)C", "issue_type": "parse_error", "severity": "error", "description": "..."}
+    ],
+    "property_distributions": {
+      "mw": {"bins": [...], "counts": [...]},
+      "logp": {"bins": [...], "counts": [...]},
+      "tpsa": {"bins": [...], "counts": [...]}
+    },
+    "std_pipeline_comparison": {...},
+    "std_sample_size": 100,
+    "dedup_groups": [{"inchikey": "...", "rows": [12, 88]}]
+  },
+  "contradictions": [
+    {
+      "inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+      "entries": [
+        {"row_index": 5, "smiles": "...", "activity": 7.2},
+        {"row_index": 203, "smiles": "...", "activity": 4.1}
+      ],
+      "fold_difference": 1259.0,
+      "entry_count": 2,
+      "smiles": "CC(=O)Oc1ccccc1C(=O)O"
+    }
+  ],
+  "numeric_columns": [
+    {"name": "pIC50", "priority": 1},
+    {"name": "MW", "priority": 2}
+  ],
+  "curation_report": {...},
+  "curated_csv_available": true
+}
+```
+
+### 4. Compare two dataset versions (diff)
+
+Upload the comparison file against a completed primary job:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/dataset/<job_id>/diff \
+  -F "file=@bioactivity_v2.csv"
+```
+
+Response:
+
+```json
+{
+  "added": [{"inchikey": "...", "smiles": "...", "row_index": 12, "properties": {...}, "changes": []}],
+  "removed": [...],
+  "modified": [{"inchikey": "...", "changes": [{"column": "pIC50", "old_value": 6.2, "new_value": 7.1}]}],
+  "added_count": 45,
+  "removed_count": 12,
+  "modified_count": 89,
+  "unchanged_count": 854,
+  "unique_columns_primary": 2,
+  "unique_columns_comparison": 3
+}
+```
+
+Diff uses InChIKey as the primary key, so it's robust to SMILES notation differences.
+
+### 5. Downloads
+
+```bash
+# Full curation report JSON
+curl -sS http://localhost:8000/api/v1/dataset/<job_id>/download/report \
+  -o curation_report.json
+
+# Curated CSV — original rows + appended diagnostic columns
+curl -sS http://localhost:8000/api/v1/dataset/<job_id>/download/csv \
+  -o curated.csv
+```
+
+Curated CSV appends: `_health_issues` (joined issue types), `_is_duplicate` (bool), `_standardized_smiles`, `_alert_flags` (joined catalog names).
+
+## Examples
+
+### Example 1 — "Audit this ChEMBL bioactivity CSV for quality issues"
+
+1. `POST /dataset/upload` with `smiles_column` and `activity_column` pointing at your CSV.
+2. Poll `/status` or WS until `complete`.
+3. `GET /results` → read `health_audit.overall_score` (aim ≥ 70) and `health_audit.sub_scores[]` for the weakest component.
+4. Read `contradictions[]` (keeps only groups above the default 10-fold threshold — check `entry_count` and `fold_difference` per group).
+5. If any `issues` have `severity="error"`, those rows need manual review.
+
+### Example 2 — "Compare v1 and v2 of a training set"
+
+1. Upload v1 and wait for `complete` → capture `job_id_v1`.
+2. `POST /dataset/<job_id_v1>/diff` with the v2 file.
+3. Read `added_count`, `removed_count`, `modified_count` for an overview.
+4. For details on changed labels: `modified[]` contains `changes[]` arrays — look for activity-column changes.
+
+### Example 3 — "Generate a curation report for my supervisor"
+
+1. Audit as in example 1.
+2. `GET /download/report` → JSON you can paste into an appendix or render as markdown.
+3. `GET /download/csv` → drop-in replacement dataset with diagnostic columns.
+
+## Rate limits
+
+- `/dataset/upload`: 3/min.
+- `/dataset/<job_id>/status`: 60/min.
+- `/dataset/<job_id>/results`: 30/min.
+- `/dataset/<job_id>/diff`: 10/min.
+- `/dataset/<job_id>/download/*`: 10/min.
+
+## Troubleshooting
+
+### 400 "Invalid file type. Please upload a CSV or SDF file."
+
+Only `.csv` and `.sdf` extensions accepted — `.tsv`, `.txt`, etc. are rejected by dataset-intelligence (unlike batch validation which accepts all four).
+
+### 413 "File exceeds maximum size limit"
+
+Check `/api/v1/config` for the deployment limit. Split the file or redeploy with a larger profile.
+
+### 202 response on `/results`
+
+Job is still running. Keep polling `/status` (lighter endpoint) until `status` flips to `complete` or `error`.
+
+### 400 "Primary dataset job is not yet complete"
+
+Diff endpoint needs the primary job to finish first. Wait until the primary shows `status=complete` in `/status`.
+
+### `activity_column` auto-detected wrong column
+
+Specify it explicitly. The auto-detector ranks by name heuristics and numeric-column detection; numeric columns are returned in `numeric_columns[]` sorted by `priority`.
+
+### `contradictions` empty when you expect conflicts
+
+The default fold threshold is 10. Lower-fold conflicts aren't reported unless you customize the threshold (currently set server-side; contact admin to change). Check `entries[]` length — duplicates below threshold are listed but won't appear as contradictions.
+
+### `std_consistency` score very low
+
+All three standardization pipelines (RDKit vs ChEMBL vs minimal) disagreed for many molecules. Usually means the dataset has unusual edge cases (metal complexes, large fragments, unusual charges). Look at `std_pipeline_comparison` for per-pipeline statistics.
+
+### No `curated_csv_available` in results
+
+The Celery worker failed mid-curation-report step. Re-upload. If it persists, check worker logs.
+
+## Further reading
+
+- `chemaudit-qsar-ready` — once the audit reveals issues, curate per molecule with provenance.
+- `chemaudit-standardization` — per-molecule investigation of why two SMILES share an InChIKey.
+- `chemaudit-diagnostics` — pre-flight file integrity checks before upload.

--- a/skills/chemaudit-diagnostics/SKILL.md
+++ b/skills/chemaudit-diagnostics/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: chemaudit-diagnostics
+description: >
+  Diagnose SMILES parse errors with position and fix suggestions, compare InChI
+  strings layer-by-layer, check format round-trip lossiness (SMILES→InChI→SMILES
+  and SMILES→MOL→SMILES), compare three standardization pipelines side-by-side,
+  and pre-validate SDF/CSV files for structural integrity. Use when user says
+  "why does this SMILES fail", "diagnose this structure", "InChI diff", "layer
+  comparison", "round-trip check", "compare InChI strings", "file pre-validation",
+  "SDF integrity", "M END missing", or "fix this SMILES error".
+license: MIT
+allowed-tools: "Bash(curl:*) Bash(python:*)"
+compatibility: >
+  Requires a running ChemAudit instance. No external dependencies beyond the API.
+metadata:
+  author: Kohulan Rajan
+  version: 1.0.0
+  mcp-server: chemaudit
+  category: cheminformatics
+  tags: [SMILES, InChI, diagnostics, error-detection, file-validation]
+---
+
+# ChemAudit Diagnostics
+
+## Overview
+
+Five targeted diagnostic endpoints. Each answers a different "why didn't this work?" question.
+
+| Endpoint | Answers |
+|---|---|
+| `POST /api/v1/diagnostics/smiles` | "Why does this SMILES fail to parse?" |
+| `POST /api/v1/diagnostics/inchi-diff` | "How do these two InChI strings differ?" |
+| `POST /api/v1/diagnostics/roundtrip` | "Does this SMILES survive a round-trip through InChI (or MOL)?" |
+| `POST /api/v1/diagnostics/cross-pipeline` | "Do three different standardization pipelines agree?" |
+| `POST /api/v1/diagnostics/file-prevalidate` | "Is this SDF/CSV structurally sound before batch upload?" |
+
+## Workflow
+
+### 1. SMILES error diagnostics (DIAG-01)
+
+Uses a dual strategy: RDKit `DetectChemistryProblems` for parseable-but-problematic SMILES, log-capture for unparseable SMILES. Returns error type, character position, and ranked fix suggestions.
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/diagnostics/smiles \
+  -H 'Content-Type: application/json' \
+  -d '{"smiles": "C(C)(C)(C)(C)C"}'
+```
+
+Response:
+
+```json
+{
+  "valid": false,
+  "canonical_smiles": null,
+  "warnings": [],
+  "errors": [
+    {
+      "raw_message": "Explicit valence for atom ... is 5, is greater than permitted",
+      "position": 0,
+      "error_type": "valence_error",
+      "message": "Carbon at position 0 has 5 bonds (max: 4)",
+      "suggestions": [
+        {
+          "description": "Remove one neighbor branch",
+          "corrected_smiles": "C(C)(C)(C)C",
+          "confidence": 0.9
+        }
+      ]
+    }
+  ]
+}
+```
+
+Error types returned: `unmatched_bracket`, `valence_error`, `ring_closure_mismatch`, `unknown_atom_symbol`, `invalid_charge`, `parse_error`.
+
+For valid-but-suspicious SMILES, `valid: true` with populated `warnings[]` (RDKit chemistry warnings, e.g. kekulization issues).
+
+### 2. InChI layer diff (DIAG-02)
+
+Pure string comparison — no RDKit. Parses each InChI into its constituent layers and produces a per-layer diff table.
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/diagnostics/inchi-diff \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "inchi_a": "InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)",
+    "inchi_b": "InChI=1S/C9H8O4/c1-6(10)13-8-5-3-2-4-7(8)9(11)12/h2-5H,1H3,(H,11,12)/t7-/m1/s1"
+  }'
+```
+
+Response:
+
+```json
+{
+  "identical": false,
+  "layer_rows": [
+    {"layer": "formula", "value_a": "C9H8O4", "value_b": "C9H8O4", "match": true},
+    {"layer": "connections", "value_a": "c1-6(...)", "value_b": "c1-6(...)", "match": true},
+    {"layer": "hydrogens", "value_a": "h2-5H,1H3,(H,11,12)", "value_b": "h2-5H,1H3,(H,11,12)", "match": true},
+    {"layer": "stereo_tetrahedral", "value_a": null, "value_b": "t7-", "match": false},
+    {"layer": "stereo_parity", "value_a": null, "value_b": "m1", "match": false},
+    {"layer": "stereo_marker", "value_a": null, "value_b": "s1", "match": false}
+  ],
+  "layers_a": {"formula": "C9H8O4", "connections": "...", "hydrogens": "..."},
+  "layers_b": {"formula": "C9H8O4", "connections": "...", "hydrogens": "...", "stereo_tetrahedral": "t7-", ...}
+}
+```
+
+Great for answering "same compound, stereo-defined vs racemic?" at a glance — rows with `match=false` isolate the exact disagreement.
+
+### 3. Format round-trip (DIAG-03)
+
+Does the molecule survive conversion to an intermediate and back?
+
+```bash
+# SMILES → InChI → SMILES (detects stereo/isotope loss)
+curl -sS -X POST http://localhost:8000/api/v1/diagnostics/roundtrip \
+  -H 'Content-Type: application/json' \
+  -d '{"smiles": "C[C@H](N)C(=O)O", "route": "smiles_inchi_smiles"}'
+
+# SMILES → MOL block → SMILES (detects stereo/charge loss)
+curl -sS -X POST http://localhost:8000/api/v1/diagnostics/roundtrip \
+  -H 'Content-Type: application/json' \
+  -d '{"smiles": "...", "route": "smiles_mol_smiles"}'
+```
+
+Response:
+
+```json
+{
+  "route": "smiles_inchi_smiles",
+  "original_smiles": "C[C@H](N)C(=O)O",
+  "intermediate": "InChI=1S/C3H7NO2/c1-2(4)3(5)6/h2H,4H2,1H3,(H,5,6)/t2-/m0/s1",
+  "roundtrip_smiles": "C[C@H](N)C(=O)O",
+  "lossy": false,
+  "losses": [],
+  "error": null
+}
+```
+
+When lossy:
+
+```json
+{
+  "lossy": true,
+  "losses": [
+    {"type": "stereo", "description": "2 stereocenters lost", "before": 2, "after": 0},
+    {"type": "isotope", "description": "Isotope label stripped", "before": 1, "after": 0}
+  ]
+}
+```
+
+Loss types: `stereo`, `charge`, `isotope`.
+
+### 4. Cross-pipeline standardization comparison (DIAG-04)
+
+Runs the molecule through **three** pipelines and compares outputs. Useful for picking which pipeline to use on a new dataset, or diagnosing why standardized SMILES disagree between sources.
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/diagnostics/cross-pipeline \
+  -H 'Content-Type: application/json' \
+  -d '{"molecule": "CC(=O)Oc1ccccc1C(=O)[O-].[Na+]", "format": "auto"}'
+```
+
+Response:
+
+```json
+{
+  "pipelines": [
+    {
+      "name": "RDKit MolStandardize",
+      "smiles": "CC(=O)Oc1ccccc1C(=O)O",
+      "inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+      "mw": 180.157,
+      "formula": "C9H8O4",
+      "charge": 0,
+      "stereo_count": 0,
+      "error": null,
+      "highlight_atoms": [],
+      "highlight_bonds": []
+    },
+    {"name": "ChEMBL Pipeline", ...},
+    {"name": "Minimal", "smiles": "CC(=O)Oc1ccccc1C(=O)[O-].[Na+]", ...}
+  ],
+  "disagreements": 3,
+  "structural_disagreements": 1,
+  "all_agree": false,
+  "property_comparison": [
+    {"property": "smiles", "values": [...], "agrees": false, "structural": true},
+    {"property": "inchikey", "values": [...], "agrees": false, "structural": true},
+    {"property": "mw", "values": [180.157, 180.157, 203.14], "agrees": false, "structural": false},
+    ...
+  ]
+}
+```
+
+`highlight_atoms` / `highlight_bonds` mark atoms outside the cross-pipeline MCS — useful for rendering a side-by-side visual diff in the UI.
+
+### 5. File pre-validation (DIAG-05)
+
+Catches file-level problems before you pay the cost of a batch upload.
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/diagnostics/file-prevalidate \
+  -F "file=@compounds.sdf"
+```
+
+Response (SDF):
+
+```json
+{
+  "file_type": "sdf",
+  "total_blocks": 1000,
+  "total_rows": null,
+  "encoding": null,
+  "issue_count": 3,
+  "issues": [
+    {"block": 42, "line": 1250, "issue_type": "missing_m_end", "severity": "error",
+     "description": "Block 42 is missing the 'M  END' terminator"},
+    {"block": 87, "line": 2310, "issue_type": "malformed_count_line", "severity": "error",
+     "description": "Block 87 has a malformed counts line"},
+    {"block": null, "line": null, "issue_type": "suspicious_content", "severity": "warning",
+     "description": "Found pattern that could indicate embedded code"}
+  ],
+  "valid": false
+}
+```
+
+Response (CSV):
+
+```json
+{
+  "file_type": "csv",
+  "total_blocks": null,
+  "total_rows": 500,
+  "encoding": "utf-8",
+  "issue_count": 1,
+  "issues": [
+    {"block": null, "line": null, "issue_type": "missing_smiles_column", "severity": "error",
+     "description": "No column matches 'SMILES' (case-insensitive)"}
+  ],
+  "valid": false
+}
+```
+
+Issue types: `missing_m_end`, `malformed_count_line`, `encoding_fallback`, `encoding_error`, `suspicious_content`, `missing_smiles_column`, `empty_rows`, `empty_file`, `duplicate_columns`.
+
+Severity levels: `error`, `warning`, `info`. `valid=false` only when at least one `error` severity appears — warnings don't block validity.
+
+Max upload size: 50 MB (hard-coded in this endpoint).
+
+## Examples
+
+### Example 1 — "This SMILES fails to parse; what's wrong?"
+
+1. `POST /diagnostics/smiles` with the bad SMILES.
+2. Read `errors[0].error_type` and `message` — tells you *what*.
+3. Read `errors[0].position` — tells you *where* in the string.
+4. Try `errors[0].suggestions[0].corrected_smiles` — first suggestion is ranked highest confidence.
+
+### Example 2 — "I have two InChI strings for the 'same' compound — are they really the same?"
+
+1. `POST /diagnostics/inchi-diff` with both.
+2. Check `identical` — if `true`, you're done.
+3. If `false`, scan `layer_rows[]` for rows with `match=false`. Formula differences mean different compounds; only stereo/isotope differences mean "same skeleton, different specification".
+
+### Example 3 — "Will my dataset survive saving as an SDF?"
+
+1. For each distinct SMILES, `POST /diagnostics/roundtrip` with `route="smiles_mol_smiles"`.
+2. Any entry with `lossy=true` means something will be lost when saving. The `losses[]` array tells you what.
+3. Stereo loss is the most common — MOL v2000 handles it poorly for some R/S cases. If it matters, save as SDF v3000 or export as SMILES instead.
+
+### Example 4 — "Pre-flight an SDF before a 10k-molecule batch"
+
+1. `POST /diagnostics/file-prevalidate` with the file.
+2. If `valid=true`, go straight to `/batch/upload`.
+3. If `valid=false`, fix each `severity=error` issue; warnings can be ignored at your discretion. Common fix: append `M  END` to blocks missing it, or re-save from RDKit.
+
+## Rate limits
+
+- `/diagnostics/smiles`, `/diagnostics/inchi-diff`, `/diagnostics/roundtrip`: 30/min.
+- `/diagnostics/cross-pipeline`, `/diagnostics/file-prevalidate`: 10/min.
+
+## Troubleshooting
+
+### 400 "Invalid characters in SMILES string"
+
+The validator blocks `< > & ; | $ \``. These chars are never valid in SMILES — strip client-side.
+
+### `errors[]` is empty but `valid=false`
+
+Rare but possible for cases where the parse error is in the RDKit C++ layer with no accompanying log message. Try `/standardize` to see if the ChEMBL pipeline's error message is more informative.
+
+### Round-trip shows lossy for SMILES that "should" work
+
+Check `losses[].type`:
+- `stereo`: the intermediate format doesn't encode your stereo (e.g. atropisomerism).
+- `isotope`: InChI's optional isotope layer was dropped in the round trip (shouldn't happen with standard InChI but occasionally does on edge cases).
+- `charge`: MOL v2000 loses some charge states.
+
+### Cross-pipeline: all three disagree
+
+Usually means the input is unusual (organometallic, radical, mixture). Treat each pipeline's output as "one opinion of many" and pick the one matching the source database's convention (ChEMBL for ChEMBL-derived data, RDKit for exotic cases).
+
+### File pre-validation: encoding_fallback warning
+
+The file wasn't valid UTF-8; the validator fell back to Latin-1 and succeeded. Usually fine but worth noting — re-save as UTF-8 if you'll reuse the file.
+
+### File pre-validation: suspicious_content
+
+Pattern-matched against script/macro patterns. False positives happen on legitimate SMILES containing `<`, `>`, or similar characters (rare). Audit-logged server-side regardless.
+
+## Further reading
+
+- `chemaudit-molecule-validation` — for check-level issues once a SMILES parses.
+- `chemaudit-standardization` — for the ChEMBL-style standardization pipeline.
+- `chemaudit-batch-validation` — pair `/file-prevalidate` with `/batch/upload`.

--- a/skills/chemaudit-molecule-validation/SKILL.md
+++ b/skills/chemaudit-molecule-validation/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: chemaudit-molecule-validation
+description: >
+  Validate and score chemical structures using ChemAudit's 16 deep validation
+  checks, 1,500+ structural alerts, and multi-rule drug-likeness scoring. Use
+  when user says "validate this molecule", "check this SMILES", "is this
+  compound valid", "ML-readiness score", "drug-likeness", "deep validation",
+  "quality score", "PAINS check", or asks about stereochemistry, valence,
+  tautomers, or structural issues. Supports SMILES, InChI, MOL blocks, IUPAC
+  names (OPSIN + PubChem), and database identifiers (ChEMBL ID, CAS, PubChem
+  CID, InChIKey) via the /resolve endpoint.
+license: MIT
+allowed-tools: "Bash(curl:*) Bash(python:*) Bash(chemaudit:*)"
+compatibility: >
+  Requires a running ChemAudit instance (docker compose up) or use the CLI
+  with --local flag for offline mode. Python 3.11+.
+metadata:
+  author: Kohulan Rajan
+  version: 1.0.0
+  mcp-server: chemaudit
+  category: cheminformatics
+  tags: [chemistry, validation, drug-discovery, SMILES, molecular-properties]
+---
+
+# ChemAudit Molecule Validation
+
+## Overview
+
+Single-molecule validation with three complementary layers:
+
+1. **Validation** (`/validate`) — 16 deep cheminformatics checks, 0-100 score.
+2. **Scoring** (`/score`) — drug-likeness (Lipinski, QED, Veber, Ghose, Egan, Muegge, Ro3), ADMET, ML-readiness, NP-likeness, safety filters.
+3. **Alerts** (`/alerts`, `/alerts/screen`) — PAINS, Brenk, NIH, ZINC, Kazius, NIBR, plus 7 ChEMBL pharma filter sets.
+
+Score interpretation: **≥70 pass, 40–69 warn, <40 fail**.
+
+## Access modes
+
+- **API**: HTTP calls to a running ChemAudit instance (default `http://localhost:8000`).
+- **CLI**: `chemaudit validate|score|standardize|profile` with `--local` for offline mode.
+- **MCP**: `chemaudit` MCP server exposes all tagged endpoints at `/mcp`.
+
+Input formats auto-detected: SMILES, InChI, MOL block, IUPAC name (OPSIN then PubChem fallback). Identifier resolution (ChEMBL ID, CAS, PubChem CID, ChEBI, UNII, DrugBank, etc.) goes through `/api/v1/resolve` first.
+
+## Workflow
+
+### 1. Quick validation (default 16 checks + scoring)
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/validate \
+  -H 'Content-Type: application/json' \
+  -d '{"molecule": "CC(=O)Oc1ccccc1C(=O)O", "format": "auto"}'
+```
+
+Response (abridged):
+
+```json
+{
+  "status": "completed",
+  "molecule_info": {
+    "canonical_smiles": "CC(=O)OC1=CC=CC=C1C(=O)O",
+    "inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+    "molecular_formula": "C9H8O4",
+    "molecular_weight": 180.16,
+    "num_stereocenters": 0,
+    "has_stereochemistry": false
+  },
+  "overall_score": 95,
+  "issues": [],
+  "all_checks": [...],
+  "execution_time_ms": 42,
+  "cached": false
+}
+```
+
+### 2. Targeted deep checks
+
+Pass specific check names instead of `"all"` (the default). Full list in `references/validation-checks.md`:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/validate \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "molecule": "CC(C)(C)C1=CC=C(C=C1)[N+](=O)[O-]",
+    "checks": ["stereoisomer_enumeration", "tautomer_detection",
+               "hypervalent_atoms", "radical_detection", "charged_species"]
+  }'
+```
+
+Each failing check returns `severity` (info/warning/error), `message`, `affected_atoms`, and a `details` dict.
+
+### 3. Drug-likeness and ADMET scoring
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/score \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "molecule": "CC(=O)Oc1ccccc1C(=O)O",
+    "include": ["druglikeness", "admet", "np_likeness", "ml_readiness",
+                "safety_filters", "consensus", "bioavailability_radar",
+                "boiled_egg"]
+  }'
+```
+
+Druglikeness returns Lipinski (0–4 violations), QED (0–1), Veber, Ro3, Ghose, Egan, Muegge. ADMET returns SAscore, ESOL solubility, Fsp3, CNS MPO, Pfizer 3/75, GSK 4/400, Golden Triangle. ML-readiness returns 0–100 with 4-dimension breakdown.
+
+### 4. Scoring profile presets (8 built-in)
+
+Profiles live in the database and are seeded at startup. Retrieve or use by ID:
+
+```bash
+curl -sS http://localhost:8000/api/v1/profiles
+```
+
+The 8 presets are: **Drug-like (Lipinski)**, **Lead-like**, **Fragment-like (Rule of 3)**, **CNS-penetrant**, **Ghose (Amgen)**, **Veber (GSK)**, **PPI-like**, **NP-like**. Presets are immutable — duplicate before editing.
+
+### 5. Structural alerts
+
+Targeted screen against a chosen set of catalogs:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/alerts \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "molecule": "CC(=O)Oc1ccccc1C(=O)O",
+    "catalogs": ["PAINS", "BRENK", "NIH", "ZINC"]
+  }'
+```
+
+Unified one-shot screen across **all** catalogs (PAINS A/B/C, BRENK, NIH, ZINC, Kazius, NIBR, 7 ChEMBL pharma filters, 21 custom SMARTS) with deduplicated concern groups:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/alerts/screen \
+  -H 'Content-Type: application/json' \
+  -d '{"molecule": "CCOC(=O)N=Nc1ccccc1"}'
+```
+
+List available catalogs:
+
+```bash
+curl -sS http://localhost:8000/api/v1/alerts/catalogs
+```
+
+**Critical caveat**: alerts are investigation flags, not rejections. 87 FDA-approved drugs contain PAINS patterns.
+
+### 6. Compound profiling (PFI, #stars, bioavailability, SA comparison)
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/profiler/full \
+  -H 'Content-Type: application/json' \
+  -d '{"smiles": "CC(=O)Oc1ccccc1C(=O)O"}'
+```
+
+Returns PFI, Abbott #stars, consensus LogP, skin permeation, CNS MPO, SA comparison (SA Score + SCScore + SYBA when installed). 3D shape descriptors are lazy — call `/profiler/shape-3d` separately.
+
+### 7. CLI usage
+
+```bash
+chemaudit validate --smiles "CC(=O)Oc1ccccc1C(=O)O"
+chemaudit validate --smiles "CCO" --local                # offline
+chemaudit validate --file compounds.csv --format json
+echo "CCO" | chemaudit validate                           # stdin
+chemaudit score --smiles "CCO" --local
+chemaudit profile --smiles "CCO"
+```
+
+`--local` bypasses the HTTP server and calls service functions directly.
+
+### 8. Identifier resolution (CAS, ChEMBL ID, PubChem CID, names)
+
+Before validating a compound given as a non-structural identifier, resolve it first:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "50-78-2", "identifier_type": "auto"}'
+```
+
+Supported types: `auto`, `smiles`, `inchi`, `inchikey`, `pubchem_cid`, `chembl_id`, `cas`, `drugbank_id`, `chebi_id`, `unii`, `wikipedia`, `name`. Response includes `canonical_smiles`, `cross_references` (CIDs, ChEMBL, DrugBank, UNII, CAS), and `resolution_chain` provenance.
+
+## Examples
+
+### Example 1 — "Validate this SMILES and tell me if it's ML-ready"
+
+1. `POST /api/v1/validate` with `{"molecule": "<smi>"}` → check `overall_score`, list `issues`.
+2. `POST /api/v1/score` with `{"molecule": "<smi>", "include": ["ml_readiness", "druglikeness"]}` → read `ml_readiness.score` (0–100) and `interpretation`.
+3. Summarise: parseable, passes Lipinski with X violations, ML-readiness = Y/100 with breakdown across 4 dimensions.
+
+### Example 2 — "Run deep validation and explain all issues"
+
+1. `POST /api/v1/validate` with `{"molecule": "<smi>", "checks": ["all"]}`.
+2. Filter `all_checks` where `passed=false`, group by `severity`.
+3. For each issue, explain the `check_name` using `references/validation-checks.md`, show `affected_atoms` and the `details` dict.
+
+### Example 3 — "Score against Lipinski, Ghose, and CNS-penetrant profiles"
+
+1. `GET /api/v1/profiles` → find IDs for `Drug-like (Lipinski)`, `Ghose (Amgen)`, `CNS-penetrant`.
+2. `POST /api/v1/score` with `{"molecule": "<smi>", "include": ["druglikeness"]}` gets Lipinski and Ghose directly.
+3. For CNS-penetrant, use `/profiler/full` → read `cns_mpo.score` and `cns_mpo.cns_penetrant` boolean.
+
+## Rate limits
+
+Anonymous (no API key):
+- 10/min: `/validate`, `/checks`, `/score`, `/score/compare`, `/alerts`, `/alerts/catalogs`, `/alerts/quick-check`, `/alerts/screen`, `/standardize`.
+- 30/min: `/validate/async`, `/validate/similarity`, `/standardize/options`, `/profiler/full`, `/profiler/efficiency`, `/profiler/mpo`.
+- 20/min: `/profiler/sa-comparison`.
+- 10/min: `/profiler/shape-3d`.
+
+API key via `X-API-Key` header raises the tier (300/min on most endpoints).
+
+## Troubleshooting
+
+### 400 "Failed to parse molecule"
+
+The detail dict includes `errors[]`, `warnings[]`, and `format_detected`. Common fixes:
+- Unbalanced ring closures — use `POST /api/v1/diagnostics/smiles` for position-specific fix suggestions.
+- IUPAC name with unusual punctuation — pass `"format": "iupac"` explicitly to force OPSIN/PubChem.
+- MOL block — ensure `M  END` terminator is present and on its own line.
+
+### 400 "Invalid characters in molecule string"
+
+The validator blocks `< > & ; | $ \``. Strip these client-side before calling.
+
+### Input auto-classified as IUPAC when it's a valid SMILES
+
+Short valid SMILES like `CO`, `O`, `CCO` are ambiguous. Pass `"input_type": "smiles"` or `"format": "smiles"` to skip name resolution.
+
+### 504 on `/validate/async`
+
+The high-priority Celery worker is unavailable. Either use the sync `/validate` endpoint or check that the `high_priority` queue worker is running (`docker compose logs worker-priority`).
+
+### 429 rate limit
+
+Use `X-API-Key` header for the 300/min tier, or stagger requests client-side. Batch endpoints (`/batch/upload`) have their own limits — see the `chemaudit-batch-validation` skill.
+
+### InChIKey-based caching
+
+`/validate` caches by `(inchikey, checks)`; repeated calls return `cached: true` with the same score. To bypass, add a meaningless suffix to `checks` or flush Redis.
+
+## Further reading
+
+- `references/validation-checks.md` — catalog of all 16 deep validation checks with severity, rationale, and fix recipes.
+- `chemaudit-batch-validation` — upload CSV/SDF for bulk validation with analytics.
+- `chemaudit-diagnostics` — when you need to know *why* a SMILES fails, not just that it did.
+- `chemaudit-standardization` — before validating heterogeneous datasets, standardize first.

--- a/skills/chemaudit-molecule-validation/references/validation-checks.md
+++ b/skills/chemaudit-molecule-validation/references/validation-checks.md
@@ -1,0 +1,62 @@
+# ChemAudit Deep Validation Checks
+
+The 16 deep validation checks registered at backend startup (see
+`EXPECTED_DEEP_VALIDATION_CHECKS` in `backend/app/main.py`). Each check returns
+`{check_name, passed, severity, message, affected_atoms, details}` via
+`POST /api/v1/validate`.
+
+Pass specific names in the `checks` field, or `["all"]` for every check.
+
+## M1.1 — Stereo & Tautomer
+
+| Check name | DVAL ID | What it flags |
+|---|---|---|
+| `stereoisomer_enumeration` | DVAL-01/02 | Undefined stereocenters; reports the count of possible stereoisomers |
+| `tautomer_detection` | DVAL-03 | Multiple tautomers possible (input may not be the canonical form) |
+| `aromatic_system_validation` | DVAL-04 | Incorrect aromaticity assignment or Kekulé inconsistencies |
+| `coordinate_dimension` | DVAL-05 | Missing or 2D-only coordinates when 3D are required |
+
+## M1.2 — Chemical Composition
+
+| Check name | DVAL ID | What it flags |
+|---|---|---|
+| `mixture_detection` | DVAL-06 | Multiple disconnected components (likely salt or mixture) |
+| `solvent_contamination` | DVAL-07 | Common solvents (water, DMSO, MeOH, EtOH, etc.) as separate fragments |
+| `inorganic_filter` | DVAL-08 | No carbon atoms in the largest fragment |
+| `radical_detection` | DVAL-09 | Unpaired electrons (radicals) on atoms |
+| `isotope_label_detection` | DVAL-10 | Non-default isotopes (²H, ¹³C, ¹⁵N, etc.) |
+| `trivial_molecule` | DVAL-11 | Fewer heavy atoms than a minimum threshold (noise) |
+
+## M1.3 — Structural Complexity
+
+| Check name | DVAL ID | What it flags |
+|---|---|---|
+| `hypervalent_atoms` | DVAL-12 | Atoms exceeding standard valence (e.g. 5-valent carbon) |
+| `polymer_detection` | DVAL-13 | Polymer repeat markers or implausibly large homopolymers |
+| `ring_strain` | DVAL-14 | Highly strained small rings (3- and 4-membered) in unusual contexts |
+| `macrocycle_detection` | DVAL-15 | Rings of ≥ 12 atoms |
+| `charged_species` | DVAL-16 | Net charge ≠ 0; lists per-atom formal charges |
+| `explicit_hydrogen_audit` | DVAL-17 | Unexpected explicit H atoms that should be implicit |
+
+## Severity semantics
+
+- `info` — reported for transparency (e.g. isotope labels), not a quality issue on its own.
+- `warning` — resolvable curation issue (mixture, unstandardized tautomer, undefined stereo).
+- `error` — structural problem that usually means the molecule should not enter an ML dataset as-is (hypervalent atoms, polymer markers, radicals).
+
+Score mapping: each failing check removes points in the scoring engine according
+to its severity. Final `overall_score` is clamped to [0, 100]. See
+`backend/app/services/validation/engine.py` for the exact weights.
+
+## Common fix recipes
+
+| Failing check | Typical fix |
+|---|---|
+| `mixture_detection` | Run the `chemaudit-standardization` pipeline; `get_parent` keeps the largest fragment. |
+| `solvent_contamination` | Same — standardization strips common solvents automatically. |
+| `tautomer_detection` | Enable `include_tautomer` in `/standardize` **only** if losing E/Z stereo is acceptable. |
+| `stereoisomer_enumeration` | Assign stereochemistry explicitly, or drop stereo via QSAR-Ready pipeline with `enable_stereo_strip: true`. |
+| `charged_species` | `/standardize` with default `Uncharger` neutralizes where chemistry permits. |
+| `inorganic_filter` | Exclude from ML dataset or confirm the compound is intentional (metal complexes). |
+| `radical_detection` | Usually an input error — re-parse from the original source. |
+| `polymer_detection` | Exclude; polymers are out of scope for small-molecule ML models. |

--- a/skills/chemaudit-qsar-ready/SKILL.md
+++ b/skills/chemaudit-qsar-ready/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: chemaudit-qsar-ready
+description: >
+  Run molecules through ChemAudit's configurable 10-step QSAR-Ready curation
+  pipeline for ML-ready SMILES with full per-step provenance and InChIKey-change
+  detection. Use when user says "QSAR ready", "prepare for QSAR", "curate for
+  ML", "standardize dataset for modeling", "strip salts and desalt", "remove
+  duplicates by InChIKey", "canonicalize tautomers for ML", "prepare SMILES for
+  machine learning", "QSAR-2D curation", or "QSAR-3D curation". Supports single
+  molecules and batch CSV/SDF files with pasted SMILES fallback.
+license: MIT
+allowed-tools: "Bash(curl:*) Bash(python:*)"
+compatibility: >
+  Requires a running ChemAudit instance. Batch mode requires Celery workers.
+metadata:
+  author: Kohulan Rajan
+  version: 1.0.0
+  mcp-server: chemaudit
+  category: cheminformatics
+  tags: [QSAR, machine-learning, curation, standardization, dataset-preparation]
+---
+
+# ChemAudit QSAR-Ready Pipeline
+
+## Overview
+
+Configurable 10-step curation pipeline that produces ML-ready canonical SMILES with duplicate detection. Per-step provenance records what changed, enabling audit trails.
+
+Pipeline steps (all toggleable except `parse` and `canonical`):
+
+| # | Step | Config flag | Default |
+|---|---|---|---|
+| 1 | `parse` — parse input SMILES | always on | on |
+| 2 | `metals` — `MetalDisconnector` | `enable_metals` | on |
+| 3 | `desalt` — `LargestFragmentChooser` | `enable_desalt` | on |
+| 4 | `normalize` — functional-group `Normalizer` | `enable_normalize` | on |
+| 5 | `neutralize` — `Uncharger` | `enable_neutralize` | on |
+| 6 | `tautomer` — `TautomerEnumerator` canonicalization | `enable_tautomer` | on |
+| 7 | `stereo` — strip stereochemistry | `enable_stereo_strip` | **off** |
+| 8 | `isotope` — strip isotope labels | `enable_isotope_strip` | on |
+| 9 | `filter` — heavy-atom / MW / inorganic composition filter | `min_heavy_atoms`, `max_heavy_atoms`, `max_mw`, `remove_inorganics` | 3–100 atoms, ≤1500 Da, no inorganics |
+| 10 | `canonical` — canonical SMILES + InChIKey | always on | on |
+
+**QSAR-2D vs QSAR-3D**: set `enable_stereo_strip: true` for 2D descriptors (all stereo removed). Keep it `false` for 3D workflows that need R/S/E/Z.
+
+## InChIKey change detection (D-14)
+
+Every run reports:
+- `original_inchikey` — from parsed input, before any steps.
+- `standardized_inchikey` — from final SMILES, after all steps.
+- `inchikey_changed` — `true` if the two differ.
+
+`inchikey_changed=true` is the canonical signal that the pipeline modified the structure in a way that matters for deduplication and downstream ML.
+
+## Status values
+
+- `ok` — successfully curated.
+- `rejected` — failed the composition filter (too few atoms, too heavy, all-inorganic).
+- `duplicate` — InChIKey matches an earlier molecule in the same batch.
+- `error` — pipeline raised an exception (unparseable input, toolkit failure).
+
+## Workflow
+
+### 1. Single molecule
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/qsar-ready/single \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "smiles": "CC(=O)Oc1ccccc1C(=O)O.[Na+].[Cl-]",
+    "config": {
+      "enable_metals": true,
+      "enable_desalt": true,
+      "enable_normalize": true,
+      "enable_neutralize": true,
+      "enable_tautomer": true,
+      "enable_stereo_strip": false,
+      "enable_isotope_strip": true,
+      "min_heavy_atoms": 3,
+      "max_heavy_atoms": 100,
+      "max_mw": 1500.0,
+      "remove_inorganics": true
+    }
+  }'
+```
+
+Response shape:
+
+```json
+{
+  "original_smiles": "CC(=O)Oc1ccccc1C(=O)O.[Na+].[Cl-]",
+  "original_inchikey": "XXXXXXXX-XXXXXXXXXX-X",
+  "curated_smiles": "CC(=O)Oc1ccccc1C(=O)O",
+  "standardized_inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+  "inchikey_changed": true,
+  "status": "ok",
+  "rejection_reason": null,
+  "steps": [
+    {"step_name": "parse", "step_index": 1, "enabled": true, "status": "applied",
+     "before_smiles": null, "after_smiles": "...", "detail": null},
+    {"step_name": "metals", "step_index": 2, "enabled": true, "status": "no_change", ...},
+    {"step_name": "desalt", "step_index": 3, "enabled": true, "status": "applied",
+     "detail": "Removed 2 fragments: Na+, Cl-"},
+    ...
+  ]
+}
+```
+
+Per-step `status` values: `applied`, `no_change`, `skipped`, `error`.
+
+### 2. Batch — file upload
+
+CSV/SDF file:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/qsar-ready/batch/upload \
+  -F 'config={"enable_metals":true,"enable_desalt":true,"enable_normalize":true,"enable_neutralize":true,"enable_tautomer":true,"enable_stereo_strip":false,"enable_isotope_strip":true,"min_heavy_atoms":3,"max_heavy_atoms":100,"max_mw":1500.0,"remove_inorganics":true}' \
+  -F "file=@compounds.csv"
+```
+
+`config` is form-encoded JSON. File is auto-detected (`.csv`, `.sdf`, `.sd`). Phase 9 file pre-validation runs first (M END terminators, encoding, empty rows) — critical issues return HTTP 422 with the pre-validation report.
+
+### 3. Batch — pasted SMILES (D-03)
+
+When you don't have a file:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/qsar-ready/batch/upload \
+  -F 'config={"enable_metals":true,"enable_desalt":true,...}' \
+  -F "smiles_text=CCO
+CC(=O)O
+c1ccccc1
+CC(=O)Oc1ccccc1C(=O)O"
+```
+
+One SMILES per line.
+
+### 4. Track progress
+
+WebSocket:
+
+```javascript
+const ws = new WebSocket(`ws://localhost:8000/ws/qsar/${job_id}`);
+ws.onmessage = (e) => console.log(JSON.parse(e.data));
+```
+
+Or poll:
+
+```bash
+curl -sS http://localhost:8000/api/v1/qsar-ready/batch/<job_id>/status
+```
+
+### 5. Paginated results
+
+```bash
+curl -sS "http://localhost:8000/api/v1/qsar-ready/batch/<job_id>/results?page=1&per_page=50"
+```
+
+Response includes `summary` with counts: `total`, `ok`, `rejected`, `duplicate`, `error`, and `steps_applied_counts` (per-step count of `applied` outcomes).
+
+### 6. Download — CSV / SDF / JSON
+
+```bash
+curl -sS "http://localhost:8000/api/v1/qsar-ready/batch/<job_id>/download/csv" -o curated.csv
+curl -sS "http://localhost:8000/api/v1/qsar-ready/batch/<job_id>/download/sdf" -o curated.sdf
+curl -sS "http://localhost:8000/api/v1/qsar-ready/batch/<job_id>/download/json" -o full_provenance.json
+```
+
+CSV columns: `original_smiles`, `curated_smiles`, `original_inchikey`, `curated_inchikey`, `inchikey_changed`, `status`, `rejection_reason`, `steps_applied` (comma-joined).
+
+SDF uses `curated_smiles` as structure, `original_inchikey` as the molecule title, and attaches `original_smiles`, `curated_smiles`, `status` as properties. Rejected and duplicate entries are skipped.
+
+JSON is the full per-molecule provenance dump plus `summary`, `config`, and a `duplicates` list.
+
+## Examples
+
+### Example 1 — "Curate this SMILES and show what changed"
+
+1. `POST /api/v1/qsar-ready/single` with `config=default`.
+2. Print `original_smiles`, `curated_smiles`, `inchikey_changed`.
+3. Walk `steps[]`; for each step where `status == "applied"`, print `step_name → detail`.
+
+### Example 2 — "QSAR-2D curation on this SDF, download cleaned CSV"
+
+1. `POST /api/v1/qsar-ready/batch/upload` with `config.enable_stereo_strip=true` and the file.
+2. WS or poll until `status=complete`.
+3. `GET /api/v1/qsar-ready/batch/<job_id>/results` → check `summary` (counts per status).
+4. `GET /api/v1/qsar-ready/batch/<job_id>/download/csv` → 2D-stripped, deduplicated SMILES.
+
+### Example 3 — "How many molecules changed InChIKey after standardization?"
+
+From the results summary isn't enough — you need per-molecule detail:
+
+1. `GET /api/v1/qsar-ready/batch/<job_id>/results?page=1&per_page=500` (or iterate pages).
+2. Count `[r for r in results if r["inchikey_changed"]]`.
+3. Slice: `[r["original_smiles"] for r in results if r["inchikey_changed"] and r["status"] == "ok"]`.
+
+## Rate limits
+
+- `/qsar-ready/single`: 30/min.
+- `/qsar-ready/batch/upload`: 3/min.
+- `/qsar-ready/batch/<job_id>/status`: 60/min.
+- `/qsar-ready/batch/<job_id>/results`: 30/min.
+- `/qsar-ready/batch/<job_id>/download/<format>`: 10/min.
+
+## Troubleshooting
+
+### 400 "Invalid config JSON"
+
+`config` must be a JSON-encoded string in the multipart form. Quote it once, don't double-encode.
+
+### 400 "Either a file or smiles_text must be provided"
+
+Batch upload needs one of the two. Pasted SMILES goes under the `smiles_text` form field, not `text` or `smiles`.
+
+### 422 "File has critical pre-validation issues"
+
+Response body has a `prevalidation` field with the `FilePreValidationResponse` payload. Most common causes: missing `M  END` in SDF, encoding mismatch in CSV, empty file. Fix the file and re-upload.
+
+### 400 "No valid SMILES found in input"
+
+File parsed OK but every row had a `parse_error`. Ensure the `SMILES` column exists (CSV auto-detects only that exact name) or pre-validate with `/diagnostics/file-prevalidate`.
+
+### 400 "Input contains N molecules. Maximum allowed is M."
+
+Hit the deployment-profile batch cap. `GET /api/v1/config` to read the limit, split the file, or redeploy with a larger profile.
+
+### status = "rejected" with `rejection_reason = "Molecule has no carbon atoms"`
+
+The composition filter (step 9) rejected an inorganic. Set `remove_inorganics: false` in config to keep them.
+
+### status = "duplicate"
+
+Another earlier molecule in the same batch canonicalized to the same InChIKey. Intentional — keeps only the first occurrence. Duplicates are written to the JSON download under `duplicates[]`.
+
+### Tautomer canonicalization stripped E/Z double-bond stereo
+
+Known behavior of `TautomerEnumerator`. If that matters, set `enable_tautomer: false` — but expect that molecules with different tautomeric forms of the same compound will produce distinct InChIKeys.
+
+## Further reading
+
+- `chemaudit-standardization` — single-molecule standardization with richer provenance.
+- `chemaudit-dataset-intelligence` — health audit across a dataset, complementary to curation.
+- `chemaudit-diagnostics` — pre-flight file validation.

--- a/skills/chemaudit-standardization/SKILL.md
+++ b/skills/chemaudit-standardization/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: chemaudit-standardization
+description: >
+  Standardize chemical structures using ChemAudit's ChEMBL-compatible pipeline
+  (Checker → Standardizer → GetParent → optional Tautomer) with full per-stage
+  provenance, charge/bond/ring-change tracking, and stereochemistry comparison.
+  Use when user says "standardize this molecule", "normalize structure", "strip
+  salts", "neutralize charges", "canonical SMILES", "ChEMBL standardization",
+  "parent molecule", "tautomer canonicalization", or "show me what changed
+  after standardization". Shows every transformation applied with before/after
+  InChIKey and atom-level diffs.
+license: MIT
+allowed-tools: "Bash(curl:*) Bash(python:*) Bash(chemaudit:*)"
+compatibility: >
+  Requires a running ChemAudit instance, or use the CLI with --local flag for
+  offline mode (no HTTP server required).
+metadata:
+  author: Kohulan Rajan
+  version: 1.0.0
+  mcp-server: chemaudit
+  category: cheminformatics
+  tags: [standardization, ChEMBL, salt-stripping, normalization, provenance]
+---
+
+# ChemAudit Standardization
+
+## Overview
+
+ChEMBL-compatible standardization pipeline with four stages:
+
+1. **Checker** — runs `ChEMBL structure checker`; detects structural problems with penalty scores (penalty>0 means the checker flagged something).
+2. **Standardizer** — fixes nitro groups, metal bonds, sulphoxides, etc. via normalization SMARTS rules.
+3. **GetParent** — extracts the largest organic fragment (removes salts, counterions, solvents).
+4. **Tautomer** (optional, off by default) — canonicalizes tautomers via `TautomerEnumerator`. **Warning**: may destroy E/Z double-bond stereochemistry.
+
+Optional detailed provenance records atom-level charge/bond/ring changes per stage.
+
+## Access modes
+
+- **API**: `POST /api/v1/standardize`.
+- **CLI**: `chemaudit standardize --smiles "CCO"` (server) or `--local` (offline).
+- **Cross-pipeline diagnostic**: `POST /api/v1/diagnostics/cross-pipeline` runs three pipelines (RDKit MolStandardize, ChEMBL-style, minimal) and compares outputs.
+
+## Workflow
+
+### 1. Default standardization
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/standardize \
+  -H 'Content-Type: application/json' \
+  -d '{"molecule": "CC(=O)Oc1ccccc1C(=O)[O-].[Na+]", "format": "auto"}'
+```
+
+Response:
+
+```json
+{
+  "molecule_info": {
+    "input_smiles": "CC(=O)Oc1ccccc1C(=O)[O-].[Na+]",
+    "canonical_smiles": "...",
+    "inchikey": "...",
+    "molecular_formula": "C9H7NaO4",
+    "molecular_weight": 203.14
+  },
+  "result": {
+    "original_smiles": "CC(=O)Oc1ccccc1C(=O)[O-].[Na+]",
+    "standardized_smiles": "CC(=O)Oc1ccccc1C(=O)O",
+    "success": true,
+    "steps_applied": [
+      {"step_name": "checker", "applied": true, "description": "ChEMBL structure checker", "changes": "Found 1 issue"},
+      {"step_name": "standardizer", "applied": true, "description": "Normalize functional groups", "changes": "No changes"},
+      {"step_name": "get_parent", "applied": true, "description": "Remove salts and counterions", "changes": "Removed 1 fragment: Na+"}
+    ],
+    "checker_issues": [
+      {"penalty_score": 5, "message": "Salt form detected"}
+    ],
+    "excluded_fragments": ["[Na+]"],
+    "stereo_comparison": {
+      "before_count": 0, "after_count": 0, "lost": 0, "gained": 0,
+      "double_bond_stereo_lost": 0, "warning": null
+    },
+    "structure_comparison": {
+      "original_atom_count": 14, "standardized_atom_count": 13,
+      "original_formula": "C9H7NaO4", "standardized_formula": "C9H8O4",
+      "original_mw": 203.14, "standardized_mw": 180.16,
+      "mass_change_percent": -11.31, "is_identical": false,
+      "diff_summary": ["Removed: Na+"]
+    },
+    "mass_change_percent": -11.31,
+    "provenance": null
+  },
+  "execution_time_ms": 87
+}
+```
+
+### 2. Enable tautomer canonicalization (opt-in)
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/standardize \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "molecule": "Oc1nc(N)nc2c1ncn2",
+    "options": {
+      "include_tautomer": true,
+      "preserve_stereo": true
+    }
+  }'
+```
+
+Adds a `tautomer_canonicalization` step. Watch `stereo_comparison.double_bond_stereo_lost` — tautomer enumeration can collapse E/Z bonds.
+
+### 3. Full provenance (atom-level diff)
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/standardize \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "molecule": "CC(=O)Oc1ccccc1C(=O)[O-].[Na+]",
+    "options": {
+      "include_provenance": true
+    }
+  }'
+```
+
+The `result.provenance` field fills with per-stage records:
+
+```json
+{
+  "stages": [
+    {
+      "stage_name": "standardizer",
+      "input_smiles": "...", "output_smiles": "...",
+      "applied": true,
+      "charge_changes": [
+        {"atom_idx": 11, "element": "O", "before_charge": -1, "after_charge": 0, "rule_name": "carboxylate", "smarts": "..."}
+      ],
+      "bond_changes": [...],
+      "radical_changes": [],
+      "ring_changes": [],
+      "fragment_removals": [],
+      "dval_cross_refs": []
+    },
+    {
+      "stage_name": "get_parent",
+      "applied": true,
+      "fragment_removals": [
+        {"smiles": "[Na+]", "name": "Sodium", "role": "counterion", "mw": 22.99}
+      ],
+      ...
+    }
+  ],
+  "tautomer": null,
+  "stereo_summary": {
+    "stereo_stripped": false, "centers_lost": 0, "bonds_lost": 0,
+    "per_center": [], "dval_cross_refs": []
+  }
+}
+```
+
+Cross-references to Deep Validation check IDs (DVAL-01, DVAL-03) appear in `dval_cross_refs` when the molecule fails those checks — useful for understanding whether standardization addressed a flagged issue.
+
+### 4. Pass prior validation results for cross-referencing
+
+If you already ran deep validation and want the standardization provenance to cross-reference DVAL IDs:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/standardize \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "molecule": "...",
+    "options": {
+      "include_provenance": true,
+      "dval_results": {
+        "undefined_stereo": {"count": 2},
+        "tautomer_detection": {"count": 1}
+      }
+    }
+  }'
+```
+
+### 5. Get available options
+
+```bash
+curl -sS http://localhost:8000/api/v1/standardize/options
+```
+
+Returns the canonical list of pipeline steps, their defaults, and warnings (e.g. tautomer stereo-loss caveat).
+
+### 6. Compare three pipelines side-by-side
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/diagnostics/cross-pipeline \
+  -H 'Content-Type: application/json' \
+  -d '{"molecule": "CC(=O)Oc1ccccc1C(=O)[O-].[Na+]", "format": "auto"}'
+```
+
+Runs:
+- RDKit `MolStandardize` (Cleanup + LargestFragment + Uncharger + TautomerEnumerator).
+- ChEMBL-style pipeline (the same as `/standardize`).
+- Minimal pipeline (parse + sanitize only).
+
+Compares SMILES, InChIKey, MW, formula, charge, stereo count across all three. Surfaces disagreements — critical when picking a pipeline for a new dataset.
+
+### 7. CLI usage
+
+```bash
+chemaudit standardize --smiles "CC(=O)Oc1ccccc1C(=O)[O-].[Na+]"
+chemaudit standardize --smiles "..." --local --format json   # offline
+chemaudit standardize --file compounds.csv                    # first line
+echo "CCO" | chemaudit standardize                            # stdin
+```
+
+`--local` uses `app.services.standardization.chembl_pipeline` directly — no HTTP. Outputs a Rich table by default, JSON when piped or `--format json`.
+
+## Stereo comparison
+
+`result.stereo_comparison` summarizes:
+
+| Field | Meaning |
+|---|---|
+| `before_count` / `after_count` | Defined stereocenters before and after |
+| `lost` / `gained` | Net change in defined stereocenters |
+| `double_bond_stereo_lost` | E/Z bonds lost to tautomerization |
+| `warning` | Populated when `lost > 0` or `double_bond_stereo_lost > 0` |
+
+`preserve_stereo: true` (default) makes the pipeline attempt to retain stereochemistry through each stage. Tautomer canonicalization is the main offender; the warning surfaces when it strips stereo.
+
+## Examples
+
+### Example 1 — "Standardize and show what changed"
+
+1. `POST /standardize` (defaults).
+2. Print `result.original_smiles` vs `result.standardized_smiles`.
+3. Loop `result.steps_applied[]`; print each step's `description` + `changes`.
+4. Print `result.excluded_fragments[]` for the salt/solvent story.
+5. Show `structure_comparison.mass_change_percent` — usually negative (lost a counterion).
+
+### Example 2 — "Why do these three SMILES have different InChIKeys?"
+
+1. `POST /diagnostics/cross-pipeline` for each — read each pipeline's InChIKey.
+2. Look at `disagreements` and `property_comparison[]` to see which property differs.
+3. If `structural_disagreements > 0`, the three standardization approaches produced different molecular graphs — investigate the per-pipeline `error` fields.
+
+### Example 3 — "Strip salts and neutralize without touching tautomers"
+
+Defaults (`include_tautomer: false`) already do this. The pipeline runs Checker → Standardizer (normalizes functional groups) → GetParent (salt stripping) — leaving tautomers alone. The result's canonical SMILES is safe to use as a dedup key without risking E/Z loss.
+
+### Example 4 — "Preserve stereochemistry in a hard case"
+
+Pass `{"options": {"preserve_stereo": true, "include_tautomer": false}}` — default. If you need tautomer canonicalization and stereo, accept that some E/Z information may be lost; the response surfaces exactly how much in `stereo_comparison.double_bond_stereo_lost`.
+
+## Rate limits
+
+- `/standardize`: 10/min.
+- `/standardize/options`: 30/min.
+- `/diagnostics/cross-pipeline`: 10/min.
+
+API-key tier raises to 300/min.
+
+## Troubleshooting
+
+### `result.success = false`
+
+The pipeline raised an exception; `result.error_message` has details. Common causes:
+- Unparseable input (also surfaces as 400 with `format_detected`).
+- Tautomer enumeration timed out (100+ tautomers) — the engine flags `complexity_flag=true`.
+- Pipeline chose a fragment with unusual chemistry (rare; open an issue with the InChIKey).
+
+### `standardized_smiles = null` but `success = true`
+
+Stripping all fragments left nothing. Means the input was entirely a salt/counterion with no parent (e.g. `[Na+].[Cl-]`). Not an error — genuinely no parent exists.
+
+### `mass_change_percent = 0` but `steps_applied` shows applied stages
+
+The standardizer applied normalizations that don't change mass (e.g. resonance structure normalization, redrawing nitro groups). Check `structure_comparison.diff_summary[]` for the qualitative story.
+
+### `double_bond_stereo_lost > 0` after enabling tautomer
+
+Expected. Tautomer canonicalization breaks and reforms double bonds. If E/Z geometry matters, set `include_tautomer: false` — accept that different tautomeric inputs will produce different canonical SMILES.
+
+### InChIKey changed but structures "look the same"
+
+Likely tautomer canonicalization, or a charge/protonation normalization. Run with `include_provenance: true` and inspect `charge_changes[]` and `bond_changes[]` to see the atom-level story.
+
+### Checker issues with `penalty_score = 0`
+
+Zero-penalty entries are informational. Non-zero penalties mean the ChEMBL checker considers the input substandard.
+
+## Further reading
+
+- `chemaudit-qsar-ready` — when you want the full 10-step ML-curation pipeline, not just the 3-4 ChEMBL steps.
+- `chemaudit-diagnostics` — for cross-pipeline comparison and SMILES round-trip checking.
+- `chemaudit-molecule-validation` — for deep checks that complement standardization.

--- a/skills/chemaudit-structure-filter/SKILL.md
+++ b/skills/chemaudit-structure-filter/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: chemaudit-structure-filter
+description: >
+  Filter generative-chemistry outputs through ChemAudit's 6-stage multi-stage
+  funnel with a composite 0-1 scorer and REINVENT 4-compatible scoring endpoint.
+  Use when user says "filter molecules", "drug-like filter", "structure filter",
+  "filter generative output", "REINVENT scoring", "REINVENT Component", "lead-like
+  filtering", "fragment filter", "funnel these SMILES", "novelty filter", or
+  "score generative batch". Four built-in presets (drug_like, lead_like,
+  fragment_like, permissive). Sync for ≤1000 SMILES, async for larger.
+license: MIT
+allowed-tools: "Bash(curl:*) Bash(python:*)"
+compatibility: >
+  Requires a running ChemAudit instance. Async batch mode requires Celery workers.
+metadata:
+  author: Kohulan Rajan
+  version: 1.0.0
+  mcp-server: chemaudit
+  category: cheminformatics
+  tags: [generative-chemistry, filtering, drug-likeness, REINVENT, virtual-screening]
+---
+
+# ChemAudit Structure Filter
+
+## Overview
+
+Multi-stage funnel for generative-chemistry outputs and virtual screening hits. Six sequential stages, each of which can reject a molecule independently:
+
+1. `parse` — RDKit parse + sanitization.
+2. `valence` — valence validity check.
+3. `alerts` — structural alert catalogs (PAINS, Brenk, Kazius, NIBR — configurable).
+4. `property` — MW, LogP, TPSA, rotatable bonds, rings within bounds.
+5. `sa_score` — synthetic accessibility score ≤ threshold.
+6. `dedup` — InChIKey-based deduplication.
+
+Optional 7th stage:
+7. `novelty` — Tanimoto similarity vs ChEMBL (gated by `enable_novelty`).
+
+Counts how many molecules enter and leave each stage (funnel diagram data).
+
+Paired with a **composite 0-1 scorer** that blends validity / QED / alert-free / SA into a single reward, useful for generative-model reinforcement learning loops. Invalid SMILES score `null`, never `0.0` (D-14 / Pitfall 4) so generative agents can distinguish "unparseable" from "parseable but terrible".
+
+REINVENT 4 Component API is supported out of the box.
+
+## Four built-in presets
+
+See `references/preset-configs.md` for full threshold details.
+
+| Preset | MW | LogP | TPSA | RotB | Rings | SA | Alerts |
+|---|---|---|---|---|---|---|---|
+| `drug_like` | 200–500 | -1 to 5 | ≤140 | ≤10 | — | ≤5.0 | PAINS + Brenk + Kazius |
+| `lead_like` | 200–350 | -1 to 3.5 | ≤140 | ≤7 | — | ≤4.0 | PAINS + Brenk + Kazius + NIBR |
+| `fragment_like` | 100–300 | -1 to 3 | ≤100 | ≤3 | ≤3 | ≤3.0 | PAINS only |
+| `permissive` | 100–800 | -5 to 8 | ≤200 | ≤15 | — | ≤7.0 | none |
+
+Weight vectors for the composite score differ per preset (D-15):
+
+| Preset | validity | qed | alert_free | sa |
+|---|---|---|---|---|
+| `drug_like` | 0.3 | 0.3 | 0.2 | 0.2 |
+| `lead_like` | 0.2 | **0.4** | 0.2 | 0.2 |
+| `fragment_like` | 0.2 | 0.2 | **0.3** | **0.3** |
+| `permissive` | **0.4** | 0.3 | 0.1 | 0.2 |
+
+## Sync vs async split (D-22)
+
+- `POST /structure-filter/filter` with ≤ 1000 SMILES → sync `FilterResponse`.
+- `POST /structure-filter/filter` with > 1000 SMILES → returns `StructureFilterBatchUploadResponse` with `job_id`, task runs on Celery.
+- `POST /structure-filter/batch/upload` (file upload) → always async.
+
+## Workflow
+
+### 1. Filter with a preset (sync, ≤1000 SMILES)
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/structure-filter/filter \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "smiles_list": ["CCO", "c1ccccc1", "CC(=O)Oc1ccccc1C(=O)O", "[Ni]"],
+    "preset": "drug_like"
+  }'
+```
+
+Response (synchronous):
+
+```json
+{
+  "input_count": 4,
+  "output_count": 1,
+  "stages": [
+    {"stage_name": "parse", "stage_index": 1, "input_count": 4, "passed_count": 4, "rejected_count": 0, "enabled": true},
+    {"stage_name": "valence", "stage_index": 2, "input_count": 4, "passed_count": 4, "rejected_count": 0, "enabled": true},
+    {"stage_name": "alerts", "stage_index": 3, "input_count": 4, "passed_count": 3, "rejected_count": 1, "enabled": true},
+    ...
+  ],
+  "molecules": [
+    {"smiles": "CCO", "status": "rejected", "failed_at": "property", "rejection_reason": "MW 46.07 below minimum 200"},
+    {"smiles": "CC(=O)Oc1ccccc1C(=O)O", "status": "passed", "failed_at": null, "rejection_reason": null},
+    ...
+  ]
+}
+```
+
+### 2. Filter with explicit config (overrides preset)
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/structure-filter/filter \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "smiles_list": ["CCO", "c1ccccc1C(=O)O"],
+    "config": {
+      "min_mw": 100, "max_mw": 400,
+      "min_logp": -1, "max_logp": 4,
+      "max_tpsa": 120, "max_rot_bonds": 8,
+      "max_rings": null, "max_sa_score": 4.5,
+      "use_pains": true, "use_brenk": true, "use_kazius": false, "use_nibr": false,
+      "enable_novelty": false, "novelty_threshold": 0.85,
+      "weight_validity": 0.25, "weight_qed": 0.35,
+      "weight_alert_free": 0.2, "weight_sa": 0.2
+    }
+  }'
+```
+
+If both `preset` and `config` are given, `preset` wins.
+
+### 3. Composite score per molecule (0-1)
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/structure-filter/score \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "smiles_list": ["CCO", "c1ccccc1C(=O)O", "invalid_smiles"],
+    "preset": "drug_like"
+  }'
+```
+
+Response: `{"scores": [0.412, 0.871, null]}`. `null` means unparseable — preserve that in downstream ML pipelines rather than coercing to 0.
+
+### 4. REINVENT 4 Component API
+
+The endpoint accepts the REINVENT 4 input contract verbatim (raw list, not wrapped in a model):
+
+```bash
+curl -sS -X POST "http://localhost:8000/api/v1/structure-filter/reinvent-score?preset=drug_like" \
+  -H 'Content-Type: application/json' \
+  -d '[
+    {"input_string": "CCO", "query_id": "q1"},
+    {"input_string": "c1ccccc1C(=O)O", "query_id": "q2"},
+    {"input_string": "invalid", "query_id": "q3"}
+  ]'
+```
+
+Response:
+
+```json
+{
+  "output": {
+    "successes_list": [
+      {"query_id": "q1", "output_value": 0.412},
+      {"query_id": "q2", "output_value": 0.871}
+    ]
+  }
+}
+```
+
+**Critical invariant**: invalid SMILES are **omitted**, not scored 0.0 (REINVENT expects this — see Pitfall 4 / D-14). Don't insert zeros yourself.
+
+REINVENT 4 `config.toml` snippet:
+
+```toml
+[[parameters.component]]
+type = "ExternalProcess"
+command = "curl -X POST http://chemaudit:8000/api/v1/structure-filter/reinvent-score?preset=drug_like -H 'Content-Type: application/json' -d @-"
+```
+
+### 5. Async batch (file upload, always async)
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/structure-filter/batch/upload \
+  -F "file=@generated_library.csv" \
+  -F "preset=lead_like"
+```
+
+Or with explicit JSON config:
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/structure-filter/batch/upload \
+  -F "file=@library.sdf" \
+  -F 'config={"min_mw":200,"max_mw":450,...}'
+```
+
+### 6. Track async progress
+
+WebSocket:
+
+```javascript
+const ws = new WebSocket(`ws://localhost:8000/ws/structure-filter/${job_id}`);
+```
+
+Poll:
+
+```bash
+curl -sS http://localhost:8000/api/v1/structure-filter/batch/<job_id>/status
+```
+
+Response: `{job_id, status, progress, current_stage}`.
+
+### 7. Async results
+
+```bash
+curl -sS http://localhost:8000/api/v1/structure-filter/batch/<job_id>/results
+```
+
+Returns the same `FilterResponse` shape wrapped in `{job_id, status, result}`.
+
+### 8. Download
+
+```bash
+# Plain text — one passed SMILES per line
+curl -sS http://localhost:8000/api/v1/structure-filter/batch/<job_id>/download/passed_txt \
+  -o passed.txt
+
+# Full CSV — every molecule with status, failed_at, rejection_reason
+curl -sS http://localhost:8000/api/v1/structure-filter/batch/<job_id>/download/full_csv \
+  -o results.csv
+```
+
+## Examples
+
+### Example 1 — "Filter 10K generated SMILES and save the passing ones"
+
+1. `POST /structure-filter/batch/upload` with the file and `preset=drug_like` → get `job_id`.
+2. Track via WS or poll `/status`.
+3. `GET /structure-filter/batch/<job_id>/download/passed_txt` → plain-text file of passed SMILES.
+
+### Example 2 — "Integrate with REINVENT"
+
+Wire the `/reinvent-score` endpoint as an `ExternalProcess` component. Choose the preset via query string. REINVENT's `query_id` round-trip is preserved; agents skip invalid SMILES naturally.
+
+### Example 3 — "Fragment-like filter on a small library"
+
+1. `POST /structure-filter/filter` with `smiles_list` (≤1000) and `preset="fragment_like"`.
+2. Read `molecules[]`, keep those with `status="passed"`.
+3. Render the funnel: `stages[]` has `input_count` / `passed_count` / `rejected_count` per stage.
+
+### Example 4 — "Turn on novelty filtering vs ChEMBL"
+
+Set `enable_novelty: true` and `novelty_threshold: 0.85` in an explicit config (no preset enables novelty by default):
+
+```bash
+curl -sS -X POST http://localhost:8000/api/v1/structure-filter/filter \
+  -H 'Content-Type: application/json' \
+  -d '{"smiles_list": [...], "config": {"min_mw": 200, "max_mw": 500, ..., "enable_novelty": true, "novelty_threshold": 0.85}}'
+```
+
+Molecules with Tanimoto > 0.85 to any ChEMBL compound are rejected at the novelty stage.
+
+## Rate limits
+
+- `/structure-filter/filter`: 20/min.
+- `/structure-filter/score`, `/structure-filter/reinvent-score`: 30/min.
+- `/structure-filter/batch/upload`: 3/min.
+- `/structure-filter/batch/<job_id>/status`: 60/min.
+- `/structure-filter/batch/<job_id>/results`: 30/min.
+- `/structure-filter/batch/<job_id>/download/<format>`: 10/min.
+
+## Troubleshooting
+
+### 400 "Unknown preset '<name>'"
+
+Valid presets: `drug_like`, `lead_like`, `fragment_like`, `permissive`. Case-sensitive.
+
+### 400 "No valid SMILES found in input"
+
+File parsed but every row errored. For CSV, ensure the column is named exactly `SMILES`. For SDF, ensure molecules have valid MOL blocks.
+
+### Score 0.0 vs null — which is it?
+
+`null` = parse failure or SMILES rejected before scoring. `0.0` = parsed and scored but every component was 0. Critical distinction for generative models; never collapse them.
+
+### REINVENT returns fewer items than I sent
+
+Expected — invalid SMILES are omitted from `successes_list`, not zero-scored. Match by `query_id`, not list position.
+
+### Async job_id found in `/status` but no results
+
+Celery worker crashed. Check `docker compose logs worker` and re-upload. Redis TTL is 1 hour on metadata.
+
+### Funnel shows 0 passed but all stages have 100% input
+
+All molecules pass individual stages but none make it through `dedup`. Means the input contains only duplicates (identical InChIKeys). Deduplicate before filtering, or disable dedup by adjusting the pipeline.
+
+### High rejection count at `alerts` stage for a fragment-screen
+
+`fragment_like` preset has only PAINS enabled. If you want Brenk filtering for fragments, use an explicit config rather than the preset.
+
+## Further reading
+
+- `references/preset-configs.md` — exhaustive threshold tables and weight vectors.
+- `chemaudit-qsar-ready` — different goal: ML-ready curation with provenance, not pass/fail filtering.
+- `chemaudit-molecule-validation` — single-molecule scoring when you need per-check detail.

--- a/skills/chemaudit-structure-filter/references/preset-configs.md
+++ b/skills/chemaudit-structure-filter/references/preset-configs.md
@@ -1,0 +1,120 @@
+# Structure Filter Preset Configurations
+
+Source of truth: `frontend/src/types/structure_filter.ts` (`PRESET_CONFIGS`) and
+`backend/app/services/structure_filter/filter_config.py` (`PRESETS`). Values below
+match the locked D-12 thresholds and D-15 differentiated weight vectors.
+
+## `drug_like`
+
+Balanced default for general drug-discovery screening. Balanced composite weights.
+
+```json
+{
+  "min_mw": 200, "max_mw": 500,
+  "min_logp": -1, "max_logp": 5,
+  "max_tpsa": 140,
+  "max_rot_bonds": 10,
+  "max_rings": null,
+  "max_sa_score": 5.0,
+  "use_pains": true, "use_brenk": true, "use_kazius": true, "use_nibr": false,
+  "enable_novelty": false, "novelty_threshold": 0.85,
+  "weight_validity": 0.3, "weight_qed": 0.3, "weight_alert_free": 0.2, "weight_sa": 0.2
+}
+```
+
+**Rationale**: Lipinski-compatible MW/LogP, Veber-compatible TPSA/RotBonds, PAINS + Brenk + Kazius on. NIBR off because it's aggressive for general HTS libraries. Balanced weights to reward overall drug-likeness without over-weighting any single component.
+
+## `lead_like`
+
+Tighter than drug-like — used during lead optimization where MW and lipophilicity should drift upward as potency is added. QED weighting emphasized.
+
+```json
+{
+  "min_mw": 200, "max_mw": 350,
+  "min_logp": -1, "max_logp": 3.5,
+  "max_tpsa": 140,
+  "max_rot_bonds": 7,
+  "max_rings": null,
+  "max_sa_score": 4.0,
+  "use_pains": true, "use_brenk": true, "use_kazius": true, "use_nibr": true,
+  "enable_novelty": false, "novelty_threshold": 0.85,
+  "weight_validity": 0.2, "weight_qed": 0.4, "weight_alert_free": 0.2, "weight_sa": 0.2
+}
+```
+
+**Rationale**: Hann & Keserű lead-like space (MW 200–350, LogP ≤ 3.5, RotBonds ≤ 7) gives room for lead→drug MW growth. All alert catalogs including NIBR on because Novartis deck filters catch many problems that survive PAINS/Brenk. Weight QED higher because drug-likeness is the lead-optimization goal.
+
+## `fragment_like`
+
+Astex Rule of 3 for fragment-based drug discovery. Emphasizes clean building blocks (alert-free, easy to synthesize).
+
+```json
+{
+  "min_mw": 100, "max_mw": 300,
+  "min_logp": -1, "max_logp": 3,
+  "max_tpsa": 100,
+  "max_rot_bonds": 3,
+  "max_rings": 3,
+  "max_sa_score": 3.0,
+  "use_pains": true, "use_brenk": false, "use_kazius": false, "use_nibr": false,
+  "enable_novelty": false, "novelty_threshold": 0.85,
+  "weight_validity": 0.2, "weight_qed": 0.2, "weight_alert_free": 0.3, "weight_sa": 0.3
+}
+```
+
+**Rationale**: Tight MW/LogP window; ring cap of 3 keeps fragments small; SA ≤ 3.0 ensures synthesizability. Only PAINS on because Brenk and Kazius patterns are rare at fragment size and false-positive rates climb. Weights emphasize alert-free and SA — the two most important qualities for a fragment-screen library.
+
+## `permissive`
+
+Escape hatch for "just check parseability and deduplicate". Alerts all off.
+
+```json
+{
+  "min_mw": 100, "max_mw": 800,
+  "min_logp": -5, "max_logp": 8,
+  "max_tpsa": 200,
+  "max_rot_bonds": 15,
+  "max_rings": null,
+  "max_sa_score": 7.0,
+  "use_pains": false, "use_brenk": false, "use_kazius": false, "use_nibr": false,
+  "enable_novelty": false, "novelty_threshold": 0.85,
+  "weight_validity": 0.4, "weight_qed": 0.3, "weight_alert_free": 0.1, "weight_sa": 0.2
+}
+```
+
+**Rationale**: Most-permissive property windows; skip the alert stages entirely; SA ≤ 7 excludes only the hardest-to-synthesize molecules. Heavy validity weight because with alerts off, "it parsed and sanitized" is the main signal.
+
+## Config field reference
+
+| Field | Type | Default (drug_like) | Meaning |
+|---|---|---|---|
+| `min_mw` / `max_mw` | float | 200 / 500 | Molecular weight window (Da) |
+| `min_logp` / `max_logp` | float | -1 / 5 | Crippen LogP window |
+| `max_tpsa` | float | 140 | Topological polar surface area (Å²) |
+| `max_rot_bonds` | int | 10 | Rotatable bonds |
+| `max_rings` | int \| null | null | Ring count cap; `null` = no limit |
+| `max_sa_score` | float | 5.0 | Ertl SA score (1 easy, 10 hard) |
+| `use_pains` | bool | true | Screen PAINS A/B/C catalogs |
+| `use_brenk` | bool | true | Screen Brenk unwanted-reactivity catalog |
+| `use_kazius` | bool | true | Screen Kazius mutagenicity toxicophores |
+| `use_nibr` | bool | false | Screen NIBR Novartis deck filters |
+| `enable_novelty` | bool | false | Add ChEMBL Tanimoto novelty stage |
+| `novelty_threshold` | float | 0.85 | Max Tanimoto to any ChEMBL compound (reject above) |
+| `weight_validity` | float | 0.3 | Composite weight: validity component |
+| `weight_qed` | float | 0.3 | Composite weight: QED component |
+| `weight_alert_free` | float | 0.2 | Composite weight: alert-free binary |
+| `weight_sa` | float | 0.2 | Composite weight: inverted SA score |
+
+Weights do not need to sum to 1; the score is normalized internally. But keeping them normalized makes comparisons across presets clearer.
+
+## Choosing between preset and custom config
+
+**Use a preset when**:
+- You want the built-in scientifically-motivated defaults.
+- You want differentiated weight vectors without computing them yourself.
+- Reproducibility with other REINVENT users matters (preset name is self-documenting).
+
+**Use a custom config when**:
+- Your project has specific MW/LogP constraints (e.g. oncology tends to relax LogP).
+- You need novelty filtering (no preset enables it).
+- You want specific alert catalogs only (e.g. Brenk on, Kazius off).


### PR DESCRIPTION
Ship the ChemAudit plugin manifest (.claude-plugin/plugin.json + root .mcp.json) plus 8 workflow-aware skills that coordinate the REST API, MCP server, and CLI for cheminformatics tasks:

- chemaudit-molecule-validation: 16 deep checks, 1,500+ alerts, scoring
- chemaudit-batch-validation: CSV/SDF bulk processing + 9 export formats
- chemaudit-qsar-ready: 10-step ML-dataset curation with provenance
- chemaudit-structure-filter: 6-stage funnel + REINVENT 4 scoring
- chemaudit-dataset-intelligence: Fourches health audit + diff + reports
- chemaudit-standardization: ChEMBL pipeline with atom-level provenance
- chemaudit-diagnostics: SMILES/InChI/file pre-validation
- chemaudit-database-integrations: PubChem/ChEMBL/COCONUT/Wikidata/SureChEMBL

All endpoint references cross-checked against backend routes; plugin manifest passes claude plugin validate; all 8 skills load via claude --plugin-dir. README updated with Agent Skills section.