### PR TITLE
Remove unused no-console eslint-disable directive

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,7 +10,6 @@ import './index.css';
 // The citation is the original SMILES paper that defines every input this
 // tool accepts. Quoted line is verbatim from the paper.
 if (typeof window !== 'undefined' && import.meta.env.MODE !== 'test') {
-  // eslint-disable-next-line no-console
   console.log(
     '%cChemAudit%c — Chemical Structure Validation\n' +
       '%cWeininger, D. J. Chem. Inf. Comput. Sci. 1989, 29(2), 97-101\n' +


### PR DESCRIPTION
The console signature commit added a // eslint-disable-next-line no-console directive next to console.log in main.tsx. The project's ESLint config does not enable no-console, so the directive was flagged as unused, failing the Lint workflow with:
  Unused eslint-disable directive (no problems were reported from
  'no-console')

Removed the directive. console.log is allowed by the lint config, so no replacement is needed.