### PR TITLE
fix(deps): cap fastapi <0.137 to avoid instrumentator route crash

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,7 +8,11 @@ version = "1.0.0"
 description = "ChemAudit Backend API"
 requires-python = ">=3.11"
 dependencies = [
-    "fastapi>=0.115.0",
+    # Cap below 0.137: that release makes include_router() store lazy _IncludedRouter
+    # objects (no .path attr) in app.routes, which crashes prometheus-fastapi-instrumentator
+    # 8.0.0 (latest) in _get_route_name -> every request 500s. Lift cap once the
+    # instrumentator gains FastAPI 0.137+ lazy-router support.
+    "fastapi>=0.115.0,<0.137",
     "uvicorn[standard]>=0.30.0",
     "gunicorn>=21.2.0",
     "pydantic>=2.8.0",


### PR DESCRIPTION
FastAPI 0.137 makes include_router() store lazy _IncludedRouter objects (no .path attr) in app.routes. prometheus-fastapi-instrumentator 8.0.0 (latest) iterates app.routes in _get_route_name and does route.path, raising AttributeError on every request -> /api/v1/health 500s -> the backend healthcheck fails -> container unhealthy -> nginx (depends_on service_healthy) never starts.

Cap fastapi >=0.115.0,<0.137 (0.136.3 is the last clean release). starlette stays 1.3.1, which the instrumentator requires (>=1.0.0). Lift the cap once the instrumentator supports FastAPI 0.137+ lazy routers.