### PR TITLE
fix(deps): cap mcp <2 so the backend imports again

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -42,6 +42,11 @@ dependencies = [
     "pillow>=12.1.1",
     "protobuf>=5.29.6",
     "fastapi-mcp>=0.4.0",
+    # fastapi-mcp 0.4.0 (its latest) declares only mcp>=1.12.0, but mcp 2.0.0
+    # made every Server() arg after `name` keyword-only, so its internal
+    # Server(name, description) call raises TypeError at import time. Cap until
+    # fastapi-mcp ships mcp 2.x support.
+    "mcp>=1.12.0,<2",
     "typer>=0.12.0",
 ]
 


### PR DESCRIPTION
## Problem

Both Backend Tests jobs on PR #149 die while collecting `tests/conftest.py`:

```
app/main.py:391: mcp = FastApiMCP(
fastapi_mcp/server.py:144: mcp_server: Server = Server(self.name, self.description)
TypeError: Server.__init__() takes 2 positional arguments but 3 were given
```

Nothing in the repo changed to cause this. `mcp` 2.0.0 was published on
2026-07-28 and moved the `*` to immediately after `name`, making every other
`Server()` argument keyword-only. `fastapi-mcp` 0.4.0 — still its latest
release — calls `Server(self.name, self.description)` positionally and declares
only `mcp>=1.12.0`, so CI resolves 2.x and the backend can no longer be
imported.

## Fix

Cap the transitive dependency in `backend/pyproject.toml`:

```toml
"mcp>=1.12.0,<2",
```

Capping is safe here: the backend reaches `mcp` only through the single
`FastApiMCP` call site in `app/main.py`. There are no `mcp.*` imports anywhere
in `app/`, `tests/`, or `scripts/`, so no code depends on 2.x APIs.

## Verification

Reproduced and confirmed in a clean venv against the real packages rather than
assumed:

| `mcp` | Result |
|---|---|
| 2.0.0 | `TypeError: Server.__init__() takes 2 positional arguments but 3 were given` |
| 1.29.0 | `FastApiMCP` constructs and mounts |

No new test — this failed at import, so pytest collection itself is the check.

## Follow-ups (not in this PR)

- Lift the cap once `fastapi-mcp` supports `mcp` 2.x. The comment in
  `pyproject.toml` records why it exists.
- `mcp.mount()` warns it is deprecated in favour of `mount_http()` (HTTP) or
  `mount_sse()` (SSE). Left alone deliberately: choosing a transport changes the
  behaviour of the `/mcp` endpoint and could break existing MCP clients.